### PR TITLE
Fix/error messages for contract

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/contract/edit/EditContractPage.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/contract/edit/EditContractPage.html
@@ -87,7 +87,7 @@
                         <button wicket:id="cancelButton2" id="cancel" type="button" class="btn bg-olive btn-block">Cancel</button>
                     </div>
                     <div class="col-lg-9">
-                        <button wicket:id="save" id="submitButton" class="btn bg-olive btn-block">Create contract / Save Changes</button>
+                        <button type="button" wicket:id="save" id="submitButton" class="btn bg-olive btn-block">Create contract / Save Changes</button>
                     </div>
                 </div>
             </div>

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/contract/edit/EditContractPage.properties
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/contract/edit/EditContractPage.properties
@@ -26,7 +26,7 @@ page.contract.selectedFile=Selected file:
 ContractType.T_UND_M=Time and Material
 ContractType.FIXED_PRICE=Fixed Price
 
-
-
-
-
+# Error messages for required fields in form
+form.contractName.Required="The contract title may not be empty."
+form.internalNumber.Required="The contract ID may not be empty."
+form.budget.Required="The budget may not be empty."

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/contract/edit/EditContractPage.properties
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/contract/edit/EditContractPage.properties
@@ -27,6 +27,8 @@ ContractType.T_UND_M=Time and Material
 ContractType.FIXED_PRICE=Fixed Price
 
 # Error messages for required fields in form
-form.contractName.Required="The contract title may not be empty."
-form.internalNumber.Required="The contract ID may not be empty."
-form.budget.Required="The budget may not be empty."
+form.contractName.Required=The contract title may not be empty.
+form.internalNumber.Required=The contract ID may not be empty.
+form.budget.Required=The budget may not be empty.
+form.taxrate=The tax rate may not be empty.
+form.startDate=The start date may not be empty.


### PR DESCRIPTION
Fix for wrong error messages in Edit Contract View by providing the string properties for the required 