### PR TITLE
Circleci/2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,14 +10,11 @@ jobs:
           command: ./gradlew --stacktrace --console=plain resolveDependencies
       - run:
           name: runTests
-          command:
-          - ./gradlew --stacktrace --console=plain build
-
-          - mkdir -p $CIRCLE_TEST_REPORTS/junit/
-          - find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
-
-          - mkdir -p $CIRCLE_TEST_REPORTS/junit-html/
-          - find . -type d -regex ".**/build/reports/tests" -exec sh -c 'cp -a {} $CIRCLE_TEST_REPORTS/junit-html/`echo {} | cut -d / -f2`' \;
-
-          - mkdir -p $CIRCLE_ARTIFACTS/build-artifacts
-          - cp -a budgeteer-web-interface/build/libs/budgeteer-web-interface-*.war $CIRCLE_ARTIFACTS/build-artifacts/
+          command: |
+            ./gradlew --stacktrace --console=plain build
+            mkdir -p $CIRCLE_TEST_REPORTS/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+            mkdir -p $CIRCLE_TEST_REPORTS/junit-html/
+            find . -type d -regex ".**/build/reports/tests" -exec sh -c 'cp -a {} $CIRCLE_TEST_REPORTS/junit-html/`echo {} | cut -d / -f2`' \;
+            mkdir -p $CIRCLE_ARTIFACTS/build-artifacts
+            cp -a budgeteer-web-interface/build/libs/budgeteer-web-interface-*.war $CIRCLE_ARTIFACTS/build-artifacts/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:8-jdk-node-browsers
+      - image: circleci/oraclejdk8
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: frolvlad/alpine-oraclejdk8:slim
+      - image: circleci/openjdk:8-jdk-node-browsers
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,19 @@ jobs:
       - image: circleci/openjdk:8-jdk-node-browsers
     steps:
       - checkout
-      - run: echo "A first hello"
+      - run:
+        name: gradleDependencies
+        command: ./gradlew --stacktrace --console=plain resolveDependencies
+      - run:
+        name: runTests
+        command:
+          - ./gradlew --stacktrace --console=plain build
+
+          - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+          - find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+
+          - mkdir -p $CIRCLE_TEST_REPORTS/junit-html/
+          - find . -type d -regex ".**/build/reports/tests" -exec sh -c 'cp -a {} $CIRCLE_TEST_REPORTS/junit-html/`echo {} | cut -d / -f2`' \;
+
+          - mkdir -p $CIRCLE_ARTIFACTS/build-artifacts
+          - cp -a budgeteer-web-interface/build/libs/budgeteer-web-interface-*.war $CIRCLE_ARTIFACTS/build-artifacts/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,18 @@ jobs:
           name: gradleDependencies
           command: ./gradlew --stacktrace --console=plain resolveDependencies
       - run:
-          name: runTests
+          name: build
+          command: ./gradlew --stacktrace --console=plain assemble
+      - run:
+          name: test
+          command: ./gradlew --stacktrace --console=plain test
+      - run:
+          name: Save test results
           command: |
-            ./gradlew --stacktrace --console=plain build
-            mkdir -p $CIRCLE_TEST_REPORTS/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
-            mkdir -p $CIRCLE_TEST_REPORTS/junit-html/
-            find . -type d -regex ".**/build/reports/tests" -exec sh -c 'cp -a {} $CIRCLE_TEST_REPORTS/junit-html/`echo {} | cut -d / -f2`' \;
-            mkdir -p $CIRCLE_ARTIFACTS/build-artifacts
-            cp -a budgeteer-web-interface/build/libs/budgeteer-web-interface-*.war $CIRCLE_ARTIFACTS/build-artifacts/
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: ~/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,8 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/openjdk:8-jdk-node-browsers
+    steps:
+      - checkout
+      - run: echo "A first hello"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/oraclejdk8
+      - image: frolvlad/alpine-oraclejdk8:slim
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,11 @@ jobs:
     steps:
       - checkout
       - run:
-        name: gradleDependencies
-        command: ./gradlew --stacktrace --console=plain resolveDependencies
+          name: gradleDependencies
+          command: ./gradlew --stacktrace --console=plain resolveDependencies
       - run:
-        name: runTests
-        command:
+          name: runTests
+          command:
           - ./gradlew --stacktrace --console=plain build
 
           - mkdir -p $CIRCLE_TEST_REPORTS/junit/

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/AbstractWebTestTemplate.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/AbstractWebTestTemplate.java
@@ -1,16 +1,32 @@
 package org.wickedsource.budgeteer.web;
 
 import org.apache.wicket.util.tester.WicketTester;
+import org.joda.money.CurrencyUnit;
+import org.joda.money.Money;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.wickedsource.budgeteer.MoneyUtil;
+import org.wickedsource.budgeteer.service.budget.BudgetBaseData;
+import org.wickedsource.budgeteer.service.budget.BudgetDetailData;
+import org.wickedsource.budgeteer.service.budget.BudgetService;
+import org.wickedsource.budgeteer.service.imports.Import;
+import org.wickedsource.budgeteer.service.imports.ImportService;
+import org.wickedsource.budgeteer.service.person.PersonDetailData;
+import org.wickedsource.budgeteer.service.person.PersonService;
 import org.wickedsource.budgeteer.service.project.ProjectService;
+import org.wickedsource.budgeteer.service.record.AggregatedRecord;
+import org.wickedsource.budgeteer.service.record.RecordService;
 import org.wickedsource.budgeteer.service.user.User;
+import org.wickedsource.budgeteer.service.user.UserService;
 import org.wickedsource.budgeteer.web.pages.administration.Project;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
+import java.util.Random;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
@@ -22,14 +38,29 @@ public abstract class AbstractWebTestTemplate {
     @Autowired
     BudgeteerApplication application;
 
-    @Autowired private ProjectService projectServiceMock;
+    @Autowired protected ProjectService projectServiceMock;
+    @Autowired protected BudgetService budgetServiceMock;
+    @Autowired protected RecordService recordServiceMock;
+    @Autowired protected UserService userServiceMock;
+    @Autowired protected ImportService importServiceMock;
+    @Autowired protected PersonService personServiceMock;
+
+
 
     private static WicketTester tester;
 
     @BeforeEach
     public void setUp() {
-        when(getProjectServiceMock().findProjectById(anyLong()))
-                .thenReturn(new Project(0,new Date(), new Date(),"test"));
+        // Provide default recordServiceMock mocks for tests.
+        // If required, explicit behavior can be implemented for each test class in setupTest()
+        when(projectServiceMock.findProjectById(anyLong())).thenReturn(new Project(0,new Date(), new Date(),"test"));
+        when(budgetServiceMock.loadBudgetBaseData(anyLong())).thenReturn(new BudgetBaseData(0, "test"));
+        when(budgetServiceMock.loadBudgetDetailData(1L)).thenReturn(createBudget());
+        when(recordServiceMock.getWeeklyAggregationForPerson(1L)).thenReturn(getWeeklyAggregationForPerson(1L));
+        when(userServiceMock.getUsersInProject(1L)).thenReturn(getUsersInProject());
+        when(importServiceMock.loadImports(1L)).thenReturn(createImports());
+        when(personServiceMock.loadPersonDetailData(1L)).thenReturn(createPerson());
+
         if (tester == null) {
             tester = new WicketTester(application);
             login();
@@ -50,11 +81,71 @@ public abstract class AbstractWebTestTemplate {
         BudgeteerSession.get().login(user);
     }
 
+    private List<AggregatedRecord> getWeeklyAggregationForPerson(long personId) {
+        Random random = new Random();
+        List<AggregatedRecord> list = new ArrayList<AggregatedRecord>();
+        for (int i = 0; i < 20; i++) {
+            AggregatedRecord record = new AggregatedRecord();
+            record.setAggregationPeriodTitle("Week #" + i);
+            record.setAggregationPeriodStart(new Date());
+            record.setAggregationPeriodStart(new Date());
+            record.setBudgetBurned(MoneyUtil.createMoneyFromCents(random.nextInt(8000)));
+            record.setBudgetPlanned(MoneyUtil.createMoneyFromCents(random.nextInt(4000)));
+            record.setHours(random.nextDouble());
+            list.add(record);
+        }
+        return list;
+    }
+
+    private List<User> getUsersInProject() {
+        List<User> users = new ArrayList<User>();
+        for (int i = 1; i <= 5; i++) {
+            User user = new User();
+            user.setId(i);
+            user.setName("User " + i);
+            users.add(user);
+        }
+        return users;
+    }
+
+    private BudgetDetailData createBudget() {
+        BudgetDetailData budgetDetailData = new BudgetDetailData();
+        budgetDetailData.setId(1L);
+        budgetDetailData.setName("Budget 1");
+        budgetDetailData.setContractId(2L);
+        budgetDetailData.setContractName("Contract");
+        budgetDetailData.setTotal(Money.of(CurrencyUnit.EUR, 123));
+        budgetDetailData.setSpent(Money.of(CurrencyUnit.EUR, 43));
+        return budgetDetailData;
+    }
+
+
+    private List<Import> createImports() {
+        List<Import> list = new ArrayList<Import>();
+        for (int i = 0; i < 20; i++) {
+            Import importRecord = new Import();
+            importRecord.setEndDate(new Date());
+            importRecord.setStartDate(new Date());
+            importRecord.setImportDate(new Date());
+            importRecord.setImportType("aproda import");
+            list.add(importRecord);
+        }
+        return list;
+    }
+
+    private PersonDetailData createPerson() {
+        PersonDetailData data = new PersonDetailData();
+        data.setAverageDailyRate(MoneyUtil.createMoney(100.0));
+        data.setName("Tom Hombergs");
+        data.setBudgetBurned(MoneyUtil.createMoney(100000.00));
+        data.setFirstBookedDate(new Date());
+        data.setHoursBooked(100.0);
+        data.setLastBookedDate(new Date());
+        return data;
+    }
+
     protected WicketTester getTester() {
         return tester;
     }
 
-    protected ProjectService getProjectServiceMock() {
-        return projectServiceMock;
-    }
 }

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/AbstractWebTestTemplate.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/AbstractWebTestTemplate.java
@@ -6,7 +6,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.wickedsource.budgeteer.service.project.ProjectService;
 import org.wickedsource.budgeteer.service.user.User;
+import org.wickedsource.budgeteer.web.pages.administration.Project;
+
+import java.util.Date;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = {"classpath:spring-web.xml", "classpath:spring-service-mock.xml"})
@@ -15,10 +22,14 @@ public abstract class AbstractWebTestTemplate {
     @Autowired
     BudgeteerApplication application;
 
+    @Autowired private ProjectService projectServiceMock;
+
     private static WicketTester tester;
 
     @BeforeEach
     public void setUp() {
+        when(getProjectServiceMock().findProjectById(anyLong()))
+                .thenReturn(new Project(0,new Date(), new Date(),"test"));
         if (tester == null) {
             tester = new WicketTester(application);
             login();
@@ -41,5 +52,9 @@ public abstract class AbstractWebTestTemplate {
 
     protected WicketTester getTester() {
         return tester;
+    }
+
+    protected ProjectService getProjectServiceMock() {
+        return projectServiceMock;
     }
 }

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/components/aggregatedrecordtable/AggregatedRecordTableTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/components/aggregatedrecordtable/AggregatedRecordTableTest.java
@@ -18,37 +18,15 @@ import static org.mockito.Mockito.when;
 
 public class AggregatedRecordTableTest extends AbstractWebTestTemplate {
 
-    @Autowired
-    private RecordService service;
-
-    private Random random = new Random();
-
     @Test
     void render() {
         WicketTester tester = getTester();
-        when(service.getWeeklyAggregationForPerson(1L)).thenReturn(getWeeklyAggregationForPerson(1L));
         PersonWeeklyAggregatedRecordsModel model = new PersonWeeklyAggregatedRecordsModel(1L);
         AggregatedRecordTable table = new AggregatedRecordTable("table", model);
         tester.startComponentInPage(table);
     }
 
-    private List<AggregatedRecord> getWeeklyAggregationForPerson(long personId) {
-        List<AggregatedRecord> list = new ArrayList<AggregatedRecord>();
-        for (int i = 0; i < 20; i++) {
-            AggregatedRecord record = new AggregatedRecord();
-            record.setAggregationPeriodTitle("Week #" + i);
-            record.setAggregationPeriodStart(new Date());
-            record.setAggregationPeriodStart(new Date());
-            record.setBudgetBurned(MoneyUtil.createMoneyFromCents(random.nextInt(8000)));
-            record.setBudgetPlanned(MoneyUtil.createMoneyFromCents(random.nextInt(4000)));
-            record.setHours(random.nextDouble());
-            list.add(record);
-        }
-        return list;
-    }
-
     @Override
     protected void setupTest() {
-
     }
 }

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/administration/ProjectAdministrationPageTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/administration/ProjectAdministrationPageTest.java
@@ -16,34 +16,11 @@ import static org.mockito.Mockito.when;
 
 public class ProjectAdministrationPageTest extends AbstractWebTestTemplate {
 
-    @Autowired
-    private UserService userService;
-
-    @Autowired
-    private ProjectService projectService;
-
     @Test
     void test() {
         WicketTester tester = getTester();
-        when(userService.getUsersInProject(1L)).thenReturn(getUsersInProject());
-        when(projectService.findProjectById(anyLong())).thenReturn(getNewProject());
         tester.startPage(ProjectAdministrationPage.class);
         tester.assertRenderedPage(ProjectAdministrationPage.class);
-    }
-
-    private Project getNewProject() {
-        return new Project(1L, null, null, "TestProject");
-    }
-
-    private List<User> getUsersInProject() {
-        List<User> users = new ArrayList<User>();
-        for (int i = 1; i <= 5; i++) {
-            User user = new User();
-            user.setId(i);
-            user.setName("User " + i);
-            users.add(user);
-        }
-        return users;
     }
 
     @Override

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/base/basepage/budgetunitchoice/BudgetUnitChoiceTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/base/basepage/budgetunitchoice/BudgetUnitChoiceTest.java
@@ -13,23 +13,12 @@ import static org.mockito.Mockito.when;
 
 public class BudgetUnitChoiceTest extends AbstractWebTestTemplate {
 
-    @Autowired
-    BudgetService service;
-
     @Test
     void testRender() {
         WicketTester tester = getTester();
-        when(service.loadBudgetUnits(1L)).thenReturn(createBudgetUnits());
         BudgetUnitModel model = new BudgetUnitModel(1L);
         BudgetUnitChoice dropdown = new BudgetUnitChoice("budgetUnit", model);
         tester.startComponentInPage(dropdown);
-    }
-
-    private List<Double> createBudgetUnits() {
-        List<Double> units = new ArrayList<Double>();
-        units.add(1d);
-        units.add(500d);
-        return units;
     }
 
     @Override

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/budgets/details/BudgetDetailsPageTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/budgets/details/BudgetDetailsPageTest.java
@@ -14,29 +14,12 @@ import static org.mockito.Mockito.when;
 
 public class BudgetDetailsPageTest extends AbstractWebTestTemplate {
 
-    @Autowired
-    private BudgetService service;
-
     @Test
     void render() {
         WicketTester tester = getTester();
-        when(service.loadBudgetDetailData(1L)).thenReturn(createBudget());
-        when(service.loadBudgetBaseData(1L)).thenReturn(new BudgetBaseData(1L, "Budget 1"));
         tester.startPage(BudgetDetailsPage.class, BudgetDetailsPage.createParameters(1L));
         tester.assertRenderedPage(BudgetDetailsPage.class);
     }
-
-    private BudgetDetailData createBudget() {
-        BudgetDetailData budgetDetailData = new BudgetDetailData();
-        budgetDetailData.setId(1L);
-        budgetDetailData.setName("Budget 1");
-        budgetDetailData.setContractId(2L);
-        budgetDetailData.setContractName("Contract");
-        budgetDetailData.setTotal(Money.of(CurrencyUnit.EUR, 123));
-        budgetDetailData.setSpent(Money.of(CurrencyUnit.EUR, 43));
-        return budgetDetailData;
-    }
-
     @Override
     protected void setupTest() {
 

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/budgets/hours/BudgetHoursPageTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/budgets/hours/BudgetHoursPageTest.java
@@ -11,19 +11,11 @@ import static org.mockito.Mockito.when;
 
 public class BudgetHoursPageTest extends AbstractWebTestTemplate {
 
-    @Autowired
-    private BudgetService service;
-
     @Test
     void render() {
         WicketTester tester = getTester();
-        when(service.loadBudgetBaseData(1L)).thenReturn(createBudget());
         tester.startPage(BudgetHoursPage.class, BudgetHoursPage.createParameters(1L));
         tester.assertRenderedPage(BudgetHoursPage.class);
-    }
-
-    private BudgetBaseData createBudget() {
-        return new BudgetBaseData(1L, "Budget 1");
     }
 
     @Override

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/budgets/overview/BudgetsOverviewPageTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/budgets/overview/BudgetsOverviewPageTest.java
@@ -22,17 +22,21 @@ public class BudgetsOverviewPageTest extends AbstractWebTestTemplate {
 
     @Test
     public void netGrossLinkWithManDays(){
+        WicketTester tester = getTester();
+        tester.startPage(BudgetsOverviewPage.class);
         BudgeteerSession.get().setTaxEnabled(true);
         BudgeteerSession.get().setSelectedBudgetUnit(13.0);
-        getTester().clickLink("netGrossLink");
+        tester.clickLink("netGrossLink");
         Assertions.assertTrue(BudgeteerSession.get().isTaxEnabled());
     }
 
     @Test
     public void netGrossLink(){
+        WicketTester tester = getTester();
+        tester.startPage(BudgetsOverviewPage.class);
         BudgeteerSession.get().setTaxEnabled(true);
         BudgeteerSession.get().setSelectedBudgetUnit(1.0);
-        getTester().clickLink("netGrossLink");
+        tester.clickLink("netGrossLink");
         Assertions.assertFalse(BudgeteerSession.get().isTaxEnabled());
     }
 }

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/dashboard/DashboardPageTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/dashboard/DashboardPageTest.java
@@ -2,22 +2,13 @@ package org.wickedsource.budgeteer.web.pages.dashboard;
 
 import org.apache.wicket.util.tester.WicketTester;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.wickedsource.budgeteer.service.project.ProjectService;
 import org.wickedsource.budgeteer.web.AbstractWebTestTemplate;
-import org.wickedsource.budgeteer.web.pages.administration.Project;
-
-import java.util.Date;
-
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Mockito.when;
 
 public class DashboardPageTest extends AbstractWebTestTemplate {
 
     @Test
     public void testRender() {
         WicketTester tester = getTester();
-        //TODO Alle Services brauchen Mocks in der AbstractWebTestTemplate-Klasse
         tester.startPage(DashboardPage.class);
         tester.assertRenderedPage(DashboardPage.class);
     }

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/dashboard/DashboardPageTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/dashboard/DashboardPageTest.java
@@ -2,19 +2,27 @@ package org.wickedsource.budgeteer.web.pages.dashboard;
 
 import org.apache.wicket.util.tester.WicketTester;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.wickedsource.budgeteer.service.project.ProjectService;
 import org.wickedsource.budgeteer.web.AbstractWebTestTemplate;
+import org.wickedsource.budgeteer.web.pages.administration.Project;
+
+import java.util.Date;
+
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.when;
 
 public class DashboardPageTest extends AbstractWebTestTemplate {
 
     @Test
     public void testRender() {
         WicketTester tester = getTester();
+        //TODO Alle Services brauchen Mocks in der AbstractWebTestTemplate-Klasse
         tester.startPage(DashboardPage.class);
         tester.assertRenderedPage(DashboardPage.class);
     }
 
     @Override
     protected void setupTest() {
-
     }
 }

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/imports/ImportsOverviewPageTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/imports/ImportsOverviewPageTest.java
@@ -15,28 +15,11 @@ import static org.mockito.Mockito.when;
 
 public class ImportsOverviewPageTest extends AbstractWebTestTemplate {
 
-    @Autowired
-    private ImportService service;
-
     @Test
     void render() {
         WicketTester tester = getTester();
-        when(service.loadImports(1L)).thenReturn(createImports());
         tester.startPage(ImportsOverviewPage.class);
         tester.assertRenderedPage(ImportsOverviewPage.class);
-    }
-
-    private List<Import> createImports() {
-        List<Import> list = new ArrayList<Import>();
-        for (int i = 0; i < 20; i++) {
-            Import importRecord = new Import();
-            importRecord.setEndDate(new Date());
-            importRecord.setStartDate(new Date());
-            importRecord.setImportDate(new Date());
-            importRecord.setImportType("aproda import");
-            list.add(importRecord);
-        }
-        return list;
     }
 
     @Override

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/person/details/PersonDetailsPageTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/person/details/PersonDetailsPageTest.java
@@ -14,26 +14,11 @@ import static org.mockito.Mockito.when;
 
 public class PersonDetailsPageTest extends AbstractWebTestTemplate {
 
-    @Autowired
-    private PersonService service;
-
     @Test
     void render() {
         WicketTester tester = getTester();
-        when(service.loadPersonDetailData(1L)).thenReturn(createPerson());
         tester.startPage(PersonDetailsPage.class, PersonDetailsPage.createParameters(1L));
         tester.assertRenderedPage(PersonDetailsPage.class);
-    }
-
-    private PersonDetailData createPerson() {
-        PersonDetailData data = new PersonDetailData();
-        data.setAverageDailyRate(MoneyUtil.createMoney(100.0));
-        data.setName("Tom Hombergs");
-        data.setBudgetBurned(MoneyUtil.createMoney(100000.00));
-        data.setFirstBookedDate(new Date());
-        data.setHoursBooked(100.0);
-        data.setLastBookedDate(new Date());
-        return data;
     }
 
     @Override

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/person/details/component/PersonHighlightsPanelTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/person/details/component/PersonHighlightsPanelTest.java
@@ -16,29 +16,14 @@ import static org.mockito.Mockito.when;
 
 public class PersonHighlightsPanelTest extends AbstractWebTestTemplate {
 
-    @Autowired
-    private PersonService service;
-
     @Test
     void render() {
-        when(service.loadPersonDetailData(1L)).thenReturn(createDetailData());
         WicketTester tester = getTester();
         PersonHighlightsModel model = new PersonHighlightsModel(1L);
         PersonHighlightsPanel panel = new PersonHighlightsPanel("panel", model);
         tester.startComponentInPage(panel);
 
         tester.assertContains("Tom Hombergs");
-    }
-
-    private PersonDetailData createDetailData() {
-        PersonDetailData data = new PersonDetailData();
-        data.setAverageDailyRate(MoneyUtil.createMoney(100.0));
-        data.setName("Tom Hombergs");
-        data.setBudgetBurned(MoneyUtil.createMoney(100000.00));
-        data.setFirstBookedDate(new Date());
-        data.setHoursBooked(100.0);
-        data.setLastBookedDate(new Date());
-        return data;
     }
 
     @Override

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/person/hours/PersonHoursPageTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/person/hours/PersonHoursPageTest.java
@@ -14,28 +14,12 @@ import static org.mockito.Mockito.when;
 
 public class PersonHoursPageTest extends AbstractWebTestTemplate {
 
-    @Autowired
-    private PersonService service;
-
     @Test
     void render() {
         WicketTester tester = getTester();
-        when(service.loadPersonDetailData(1L)).thenReturn(createPerson());
         tester.startPage(PersonHoursPage.class, PersonHoursPage.createParameters(1L));
         tester.assertRenderedPage(PersonHoursPage.class);
     }
-
-    private PersonDetailData createPerson() {
-        PersonDetailData data = new PersonDetailData();
-        data.setAverageDailyRate(MoneyUtil.createMoney(100.0));
-        data.setName("Tom Hombergs");
-        data.setBudgetBurned(MoneyUtil.createMoney(100000.00));
-        data.setFirstBookedDate(new Date());
-        data.setHoursBooked(100.0);
-        data.setLastBookedDate(new Date());
-        return data;
-    }
-
     @Override
     protected void setupTest() {
 

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/person/monthreport/PersonMonthReportPageTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/person/monthreport/PersonMonthReportPageTest.java
@@ -14,26 +14,11 @@ import static org.mockito.Mockito.when;
 
 public class PersonMonthReportPageTest extends AbstractWebTestTemplate{
 
-    @Autowired
-    private PersonService service;
-
     @Test
     void test() {
         WicketTester tester = getTester();
-        when(service.loadPersonDetailData(1L)).thenReturn(createPerson());
         tester.startPage(PersonMonthReportPage.class, PersonMonthReportPage.createParameters(1L));
         tester.assertRenderedPage(PersonMonthReportPage.class);
-    }
-
-    private PersonDetailData createPerson() {
-        PersonDetailData data = new PersonDetailData();
-        data.setAverageDailyRate(MoneyUtil.createMoney(100.0));
-        data.setName("Tom Hombergs");
-        data.setBudgetBurned(MoneyUtil.createMoney(100000.00));
-        data.setFirstBookedDate(new Date());
-        data.setHoursBooked(100.0);
-        data.setLastBookedDate(new Date());
-        return data;
     }
 
     @Override

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/person/overview/PeopleOverviewTableTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/person/overview/PeopleOverviewTableTest.java
@@ -18,29 +18,12 @@ import static org.mockito.Mockito.when;
 
 public class PeopleOverviewTableTest extends AbstractWebTestTemplate {
 
-    @Autowired
-    private PersonService service;
-
     @Test
     void testRender() {
         WicketTester tester = getTester();
-        when(service.loadPeopleBaseData(1L)).thenReturn(createPersons());
         PeopleModel model = new PeopleModel(1L);
         PeopleOverviewTable table = new PeopleOverviewTable("table", model);
         tester.startComponentInPage(table);
-    }
-
-    private List<PersonBaseData> createPersons() {
-        List<PersonBaseData> list = new ArrayList<PersonBaseData>();
-        for (int i = 0; i < 20; i++) {
-            PersonBaseData person = new PersonBaseData();
-            person.setId(1L);
-            person.setAverageDailyRate(MoneyUtil.createMoney(1250.54));
-            person.setLastBooked(new Date());
-            person.setName("Martha Pfahl");
-            list.add(person);
-        }
-        return list;
     }
 
     @Override

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/person/weekreport/PersonWeekReportPageTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/person/weekreport/PersonWeekReportPageTest.java
@@ -14,26 +14,11 @@ import static org.mockito.Mockito.when;
 
 public class PersonWeekReportPageTest extends AbstractWebTestTemplate {
 
-    @Autowired
-    private PersonService service;
-
     @Test
     void test() {
         WicketTester tester = getTester();
-        when(service.loadPersonDetailData(1L)).thenReturn(createPerson());
         tester.startPage(PersonWeekReportPage.class, PersonWeekReportPage.createParameters(1L));
         tester.assertRenderedPage(PersonWeekReportPage.class);
-    }
-
-    private PersonDetailData createPerson() {
-        PersonDetailData data = new PersonDetailData();
-        data.setAverageDailyRate(MoneyUtil.createMoney(100.0));
-        data.setName("Tom Hombergs");
-        data.setBudgetBurned(MoneyUtil.createMoney(100000.00));
-        data.setFirstBookedDate(new Date());
-        data.setHoursBooked(100.0);
-        data.setLastBookedDate(new Date());
-        return data;
     }
 
     @Override

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/person/weekreport/chart/TargetAndActualChartTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/person/weekreport/chart/TargetAndActualChartTest.java
@@ -13,36 +13,11 @@ import java.util.Random;
 
 public class TargetAndActualChartTest extends AbstractWebTestTemplate {
 
-    private Random random = new Random();
-
     @Test
     void testRender() {
         WicketTester tester = getTester();
         PersonWeeklyAggregationModel model = new PersonWeeklyAggregationModel(1L);
         tester.startComponentInPage(new TargetAndActualChart("chart", model, TargetAndActualChartConfiguration.Mode.WEEKLY));
-    }
-
-    public TargetAndActual createTargetAndActual(long personId, int numberOfWeeks) {
-        TargetAndActual targetAndActual = new TargetAndActual();
-
-        for (int i = 0; i < 5; i++) {
-            MoneySeries series = new MoneySeries();
-            series.setName("Budget " + i);
-            for (int j = 0; j < numberOfWeeks; j++) {
-                series.getValues().add(MoneyUtil.createMoneyFromCents(random.nextInt(5000)));
-            }
-            targetAndActual.getActualSeries().add(series);
-        }
-
-        MoneySeries series = new MoneySeries();
-        series.setName("Target");
-        for (int j = 0; j < numberOfWeeks; j++) {
-            series.getValues().add(MoneyUtil.createMoneyFromCents(random.nextInt(5000)));
-        }
-        targetAndActual.setTargetSeries(series);
-
-        return targetAndActual;
-
     }
 
     @Override


### PR DESCRIPTION
Update project pipeline to CircleCI 2.0

This required a new CircleCI configuration file and some changes to the tests inheriting from AbstractWebTestTemplate, as CircleCI runs these tests atomic, not in batch (resulting in some fuzzy cross-test dependencies).
I also followed the boy scouts rule: "Always leave a place cleaner than you found it" and moved the mocking parts to the parent template class AbstractWebTestTemplate.
Now, the tests look much cleaner and do not concern themselves with mocking.

Right now, the mock data is loaded in Java code. It might be possible to move this data to xml configuration files, cleaning up the AbstractWebTestTemplate class.
This can be done in a future Pull Request.