### PR TITLE
Fixed keycloak login

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/login/LoginPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/login/LoginPage.java
@@ -38,7 +38,7 @@ public class LoginPage extends DialogPage {
         if (settings.isKeycloakActivated()) { // Skip Login Page if Keycloak is activated
             HttpServletRequest request = (HttpServletRequest) getRequestCycle().getRequest().getContainerRequest();
             AccessToken accessToken = ((KeycloakPrincipal) request.getUserPrincipal()).getKeycloakSecurityContext().getToken();
-            User user = userService.login(accessToken.getName());
+            User user = userService.login(accessToken.getPreferredUsername());
             BudgeteerSession.get().login(user);
             setResponsePage(new SelectProjectWithKeycloakPage());
         } else {


### PR DESCRIPTION
One issue has been that Budgeteer wanted to use the FirstName and not the Username.
Therefore the Budgeteer couldn't create a new User or login with an existing User.