### PR TITLE
Fixed issue #191 - Tags can be added to new budgets

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/budget/EditBudgetData.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/budget/EditBudgetData.java
@@ -25,11 +25,12 @@ public class EditBudgetData implements Serializable {
 
     public EditBudgetData(long projectId) {
         this.projectId = projectId;
+        this.tags = new ArrayList<>();
     }
 
     public void setTags(List<String> tags) {
         if (tags != null) {
-            this.tags = new ArrayList<String>(tags);
+            this.tags = new ArrayList<>(tags);
         }
     }
 }


### PR DESCRIPTION
Fixed a bug that caused an exception when trying to add a tag to a budget at creation time.

This closes issue #191 