### PR TITLE
[FIX-246] Exception was thrown when changing the money display unit and fixed a few warnings

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/links/NetGrossLink.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/links/NetGrossLink.html
@@ -9,7 +9,7 @@
             </div>
             <div class="icon"><i class="fa fa-book"></i></div>
             <div class="small-box-footer">
-                Shows the values of this table as net values.
+                Shows the values of this table as net/gross values.
                 <i class="fa fa-arrow-circle-right"/>
             </div>
         </div>

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/links/NetGrossLink.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/links/NetGrossLink.java
@@ -1,6 +1,7 @@
 package org.wickedsource.budgeteer.web.components.links;
 
 import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.Page;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.Link;
@@ -24,21 +25,20 @@ public class NetGrossLink extends Panel {
                 } else {
                     BudgeteerSession.get().setTaxEnabled(true);
                 }
-
             }
         };
 
-        link.add(new Label("title", new TaxSwitchLabelModel(
-                new StringResourceModel("links.tax.label.net", this),
-                new StringResourceModel("links.tax.label.gross", this)
-        )));
-
         if(Math.abs(BudgeteerSession.get().getSelectedBudgetUnit() - 1.0) > Math.ulp(1)){
             link.add(new AttributeAppender("style", "cursor: not-allowed;", " "));
-            link.add(new AttributeModifier("title", NetGrossLink.this.getString("links.budge.label.gross.value")));
+            link.add(new AttributeModifier("title", new StringResourceModel("links.budge.label.gross.value", this)));
             link.setEnabled(false);
             BudgeteerSession.get().setTaxEnabled(false);
         }
+        link.add(new Label("title", new TaxSwitchLabelModel<>(
+                new StringResourceModel("links.tax.label.net", this),
+                new StringResourceModel("links.tax.label.gross", this)
+        )));
         this.add(link);
+
     }
 }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/base/basepage/budgetunitchoice/BudgetUnitChoice.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/base/basepage/budgetunitchoice/BudgetUnitChoice.java
@@ -31,7 +31,7 @@ public class BudgetUnitChoice extends Panel {
                     @Override
                     public void onClick() {
                         session.setSelectedBudgetUnit(item.getModelObject());
-                        setResponsePage(this.getPage().getPageClass());
+                        setResponsePage(this.getPage().getPageClass(), this.getPage().getPageParameters());
                     }
                 };
                 item.add(link);

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/details/highlights/BudgetHighlightsPanel.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/details/highlights/BudgetHighlightsPanel.java
@@ -3,6 +3,7 @@ package org.wickedsource.budgeteer.web.pages.budgets.details.highlights;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.StringResourceModel;
 import org.wickedsource.budgeteer.service.budget.BudgetDetailData;
 import org.wickedsource.budgeteer.web.components.money.MoneyLabel;
 import org.wickedsource.budgeteer.web.components.nullmodel.NullsafeModel;
@@ -26,7 +27,7 @@ public class BudgetHighlightsPanel extends Panel {
     }
 
     private IModel<String> nullsafeModel(IModel<String> wrappedModel){
-        return new NullsafeModel<>(wrappedModel, getString("nullString"));
+        return new NullsafeModel<>(wrappedModel, new StringResourceModel("nullString").getString());
     }
 
 }


### PR DESCRIPTION
An exception is not thrown anymore if the money display unit is changed on certain pages (#246).
Also fixed a few warnings related to getString() methods in object constructors (NetGrossLink and BudgetHighlightsPanel). 