### PR TITLE
[potential FIX-230] - Verify the existence of the selected project in the DB before trying to access it

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/project/ProjectService.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/project/ProjectService.java
@@ -151,6 +151,10 @@ public class ProjectService {
         return new Project(entity.getId(), entity.getProjectStart(), entity.getProjectEnd(), entity.getName());
     }
 
+    public boolean doesProjectExist(long projectId) {
+        return this.projectRepository.findOne(projectId) != null;
+    }
+
     public void save(Project project) {
         ProjectEntity projectEntity = projectRepository.findOne(project.getProjectId());
         projectEntity.setName(project.getName());

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/BudgeteerSession.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/BudgeteerSession.java
@@ -1,14 +1,20 @@
 package org.wickedsource.budgeteer.web;
 
+import org.apache.wicket.injection.Injector;
 import org.apache.wicket.protocol.http.WebSession;
 import org.apache.wicket.request.Request;
+import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.wickedsource.budgeteer.service.budget.BudgetTagFilter;
+import org.wickedsource.budgeteer.service.project.ProjectService;
 import org.wickedsource.budgeteer.service.user.User;
 import org.wickedsource.budgeteer.web.pages.templates.TemplateFilter;
 
 import java.util.HashMap;
 
 public class BudgeteerSession extends WebSession {
+
+    @SpringBean
+    private ProjectService projectService;
 
     //Tags are saved in a Map and correspond to a projectID
     //This makes them persistent when switching projects
@@ -30,6 +36,8 @@ public class BudgeteerSession extends WebSession {
 
     public BudgeteerSession(Request request) {
         super(request);
+
+        Injector.get().inject(this);
     }
 
     public User getLoggedInUser() {
@@ -62,7 +70,16 @@ public class BudgeteerSession extends WebSession {
     }
 
     public boolean isProjectSelected() {
-        return projectSelected;
+        if(projectSelected) {
+            if(this.projectService.doesProjectExist(projectId)) {
+                return true;
+            } else {
+                this.setProjectSelected(false);
+                return false;
+            }
+        } else {
+            return false;
+        }
     }
 
     public void setProjectSelected(boolean projectSelected) {

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/instantiation/BudgeteerRequiresProjectListener.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/instantiation/BudgeteerRequiresProjectListener.java
@@ -23,6 +23,8 @@ import org.wickedsource.budgeteer.web.pages.user.selectproject.SelectProjectWith
  */
 public class BudgeteerRequiresProjectListener implements IComponentOnBeforeRenderListener, IComponentInstantiationListener {
 
+    private static final String ERR_NO_PROJ_MSG = "A project needs to be selected to access this page";
+
     @SpringBean
     private BudgeteerSettings settings;
 
@@ -59,7 +61,7 @@ public class BudgeteerRequiresProjectListener implements IComponentOnBeforeRende
                 if(settings.isKeycloakActivated()) {
                     throw new RestartResponseAtInterceptPageException(SelectProjectWithKeycloakPage.class);
                 } else {
-                    throw new RestartResponseAtInterceptPageException(SelectProjectPage.class);
+                    throw new RestartResponseAtInterceptPageException(new SelectProjectPage(ERR_NO_PROJ_MSG));
                 }
             }
         }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/instantiation/BudgeteerRequiresProjectListener.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/instantiation/BudgeteerRequiresProjectListener.java
@@ -23,8 +23,6 @@ import org.wickedsource.budgeteer.web.pages.user.selectproject.SelectProjectWith
  */
 public class BudgeteerRequiresProjectListener implements IComponentOnBeforeRenderListener, IComponentInstantiationListener {
 
-    private static final String ERR_NO_PROJ_MSG = "A project needs to be selected to access this page";
-
     @SpringBean
     private BudgeteerSettings settings;
 
@@ -61,7 +59,8 @@ public class BudgeteerRequiresProjectListener implements IComponentOnBeforeRende
                 if(settings.isKeycloakActivated()) {
                     throw new RestartResponseAtInterceptPageException(SelectProjectWithKeycloakPage.class);
                 } else {
-                    throw new RestartResponseAtInterceptPageException(new SelectProjectPage(ERR_NO_PROJ_MSG));
+                    final SelectProjectPage responsePage = new SelectProjectPage("chooseProjectForm.projectPresent.failed");
+                    throw new RestartResponseAtInterceptPageException(responsePage);
                 }
             }
         }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/selectproject/SelectProjectPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/selectproject/SelectProjectPage.java
@@ -52,6 +52,21 @@ public class SelectProjectPage extends DialogPageWithBacklink {
         add(feedbackForm);
     }
 
+    /**
+     * Constructs a new select project page and displays a
+     * error message.
+     *
+     * @param errMsg
+     *          A error errMsg to display.
+     */
+    public SelectProjectPage(String errMsg) {
+        this();
+
+        if(errMsg != null && !errMsg.isEmpty()) {
+            this.error(errMsg);
+        }
+    }
+
     private Form<String> createNewProjectForm(String id) {
         Form<String> form = new Form<String>(id, new Model<String>("")) {
             @Override

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/selectproject/SelectProjectPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/selectproject/SelectProjectPage.java
@@ -56,14 +56,14 @@ public class SelectProjectPage extends DialogPageWithBacklink {
      * Constructs a new select project page and displays a
      * error message.
      *
-     * @param errMsg
-     *          A error errMsg to display.
+     * @param errMsgKey
+     *          A property key.
      */
-    public SelectProjectPage(String errMsg) {
+    public SelectProjectPage(String errMsgKey) {
         this();
 
-        if(errMsg != null && !errMsg.isEmpty()) {
-            this.error(errMsg);
+        if(errMsgKey != null && !errMsgKey.isEmpty()) {
+            this.error(this.getString(errMsgKey));
         }
     }
 

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/selectproject/SelectProjectPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/selectproject/SelectProjectPage.java
@@ -116,6 +116,7 @@ public class SelectProjectPage extends DialogPageWithBacklink {
         return new Link(id) {
             @Override
             public void onClick() {
+                BudgeteerSession.get().logout();
                 setResponsePage(LoginPage.class);
             }
         };

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/selectproject/SelectProjectPage.properties
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/selectproject/SelectProjectPage.properties
@@ -2,4 +2,5 @@ newProjectForm.projectName.Required=The name of a new project may not be empty
 chooseProjectForm.projectChoice.Required=The chosen project may not be empty
 chooseProjectForm.defaultProject.successful=The default project was altered successful
 chooseProjectForm.defaultProject.failed=An error occurred while altering the default project
+chooseProjectForm.projectPresent.failed=A project needs to be selected to access this page
 newProjectForm.projectName.AlreadyInUse=The given project name is already in use

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/AbstractWebTestTemplate.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/AbstractWebTestTemplate.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Random;
 
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
@@ -54,6 +55,7 @@ public abstract class AbstractWebTestTemplate {
         // Provide default recordServiceMock mocks for tests.
         // If required, explicit behavior can be implemented for each test class in setupTest()
         when(projectServiceMock.findProjectById(anyLong())).thenReturn(new Project(0,new Date(), new Date(),"test"));
+        when(projectServiceMock.doesProjectExist(anyLong())).thenReturn(true);
         when(budgetServiceMock.loadBudgetBaseData(anyLong())).thenReturn(new BudgetBaseData(0, "test"));
         when(budgetServiceMock.loadBudgetDetailData(1L)).thenReturn(createBudget());
         when(recordServiceMock.getWeeklyAggregationForPerson(1L)).thenReturn(getWeeklyAggregationForPerson(1L));


### PR DESCRIPTION
- prevent exception throw (like in #230) by verifying existence of the selected project in the database when initiating/rendering project dependent pages like /dashboard
- added new methods to ProjectService/BudgeteerSession/SelectProjectPage

**NOT READY FOR MERGE YET**
**implementation not thread safe**