### PR TITLE
[FIX-257] Show a error message when accessing pages without having a project selected

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/instantiation/BudgeteerRequiresProjectListener.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/instantiation/BudgeteerRequiresProjectListener.java
@@ -5,6 +5,7 @@ import org.apache.wicket.RestartResponseAtInterceptPageException;
 import org.apache.wicket.application.IComponentInstantiationListener;
 import org.apache.wicket.application.IComponentOnBeforeRenderListener;
 import org.apache.wicket.injection.Injector;
+import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.wickedsource.budgeteer.web.BudgeteerSession;
 import org.wickedsource.budgeteer.web.BudgeteerSettings;
@@ -59,7 +60,8 @@ public class BudgeteerRequiresProjectListener implements IComponentOnBeforeRende
                 if(settings.isKeycloakActivated()) {
                     throw new RestartResponseAtInterceptPageException(SelectProjectWithKeycloakPage.class);
                 } else {
-                    throw new RestartResponseAtInterceptPageException(SelectProjectPage.class);
+                    final WebPage respPage = new SelectProjectPage("projectForm.project.Required");
+                    throw new RestartResponseAtInterceptPageException(respPage);
                 }
             }
         }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/selectproject/SelectProjectPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/selectproject/SelectProjectPage.java
@@ -23,6 +23,8 @@ import org.wickedsource.budgeteer.web.pages.base.dialogpage.DialogPageWithBackli
 import org.wickedsource.budgeteer.web.pages.dashboard.DashboardPage;
 import org.wickedsource.budgeteer.web.pages.user.login.LoginPage;
 
+import java.io.Serializable;
+
 @Mount("/selectProject")
 public class SelectProjectPage extends DialogPageWithBacklink {
 
@@ -50,6 +52,23 @@ public class SelectProjectPage extends DialogPageWithBacklink {
         feedbackPanel.setOutputMarkupId(true);
         feedbackForm.add(feedbackPanel);
         add(feedbackForm);
+    }
+
+    /**
+     * Construct a new SelectProjectPage and show a error message.
+     *
+     * @param propertyKey
+     *          A key to a String property of the error message
+     *          you want to display.
+     *
+     * @see #error(Serializable)
+     */
+    public SelectProjectPage(String propertyKey) {
+        this();
+
+        if(propertyKey != null && !propertyKey.isEmpty()) {
+            this.error(this.getString(propertyKey));
+        }
     }
 
     private Form<String> createNewProjectForm(String id) {

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/selectproject/SelectProjectPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/selectproject/SelectProjectPage.java
@@ -116,6 +116,7 @@ public class SelectProjectPage extends DialogPageWithBacklink {
         return new Link(id) {
             @Override
             public void onClick() {
+                BudgeteerSession.get().logout();
                 setResponsePage(LoginPage.class);
             }
         };

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/selectproject/SelectProjectPage.properties
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/selectproject/SelectProjectPage.properties
@@ -3,3 +3,4 @@ chooseProjectForm.projectChoice.Required=The chosen project may not be empty
 chooseProjectForm.defaultProject.successful=The default project was altered successful
 chooseProjectForm.defaultProject.failed=An error occurred while altering the default project
 newProjectForm.projectName.AlreadyInUse=The given project name is already in use
+projectForm.project.Required=A project needs to be selected to access this page


### PR DESCRIPTION
- implemented #257 
- added new constructor to `SelectProjectPage`
- added new property to `SelectProjectPage.properties`
- `BudgeteerRequiresProjectListener` now redirects to `SelectProjectPage` with a error message