### PR TITLE
[FIX-28] Add functionality to write notes connected to budgets

### DIFF
--- a/budgeteer-web-interface/build.gradle
+++ b/budgeteer-web-interface/build.gradle
@@ -59,6 +59,7 @@ dependencies {
             [group: 'org.apache.wicket', name: 'wicket-spring', version: "${wicket_spring_version}"],
             [group: 'org.apache.wicket', name: 'wicket-extensions', version: "${wicket_spring_version}"],
             [group: 'org.wicketstuff', name: 'wicketstuff-lazymodel', version: "${wicketstuff_lazymodel_version}"],
+            [group: 'org.wicketstuff', name: 'wicketstuff-tinymce4', version: "${wicketstuff_tinymce4_version}"],
             [group: 'de.adesso.wicked-charts', name: 'wicked-charts-wicket7', version: "${wicketcharts_version}"]
     )
 

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/budget/BudgetEntity.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/budget/BudgetEntity.java
@@ -34,6 +34,11 @@ public class BudgetEntity {
 
     private String description;
 
+    // Notes have a maximum size of 10MB
+    @Lob
+    @Column(length = 10485760)
+    private String note;
+
     private Money total;
 
     @ManyToOne(optional = false)
@@ -72,6 +77,7 @@ public class BudgetEntity {
         if (importKey != null ? !importKey.equals(that.importKey) : that.importKey != null) return false;
         if (name != null ? !name.equals(that.name) : that.name != null) return false;
         if (description != null ? !description.equals(that.description) : that.description != null) return false;
+        if (note != null ? !note.equals(that.note) : that.note != null) return false;
         if (planRecords != null ? !planRecords.equals(that.planRecords) : that.planRecords != null) return false;
         if (project != null ? !project.equals(that.project) : that.project != null) return false;
         if (tags != null ? !tags.equals(that.tags) : that.tags != null) return false;
@@ -86,6 +92,7 @@ public class BudgetEntity {
         int result = (int) (id ^ (id >>> 32));
         result = 31 * result + (name != null ? name.hashCode() : 0);
         result = 31 * result + (description != null ? description.hashCode() : 0);
+        result = 31 * result + (note != null ? note.hashCode() : 0);
         result = 31 * result + (total != null ? total.hashCode() : 0);
         result = 31 * result + (project != null ? project.hashCode() : 0);
         result = 31 * result + (tags != null ? tags.hashCode() : 0);

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/budget/BudgetEntity.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/budget/BudgetEntity.java
@@ -34,9 +34,9 @@ public class BudgetEntity {
 
     private String description;
 
-    // Notes have a maximum size of 10MB
+    // Notes have a maximum size of 10KB
     @Lob
-    @Column(length = 10485760)
+    @Column(length = 10 * 1024)
     private String note;
 
     private Money total;

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/budget/BudgetDetailData.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/budget/BudgetDetailData.java
@@ -12,6 +12,7 @@ public class BudgetDetailData {
     private long id;
     private String name;
     private String description;
+    private String note;
     private List<String> tags;
     private Money total;
     private Money total_gross;

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/budget/BudgetService.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/budget/BudgetService.java
@@ -248,6 +248,7 @@ public class BudgetService {
         data.setDescription(budget.getDescription());
         data.setTotal(budget.getTotal());
         data.setTitle(budget.getName());
+        data.setNote(budget.getNote());
         data.setTags(mapEntitiesToTags(budget.getTags()));
         data.setImportKey(budget.getImportKey());
         data.setContract(contractDataMapper.map(budget.getContract()));
@@ -273,6 +274,7 @@ public class BudgetService {
         budget.setDescription(data.getDescription());
         budget.setTotal(data.getTotal());
         budget.setName(data.getTitle());
+        budget.setNote(data.getNote());
         budget.getTags().clear();
         budget.getTags().addAll(mapTagsToEntities(data.getTags(), budget));
         if(data.getContract() == null) {

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/budget/EditBudgetData.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/budget/EditBudgetData.java
@@ -17,6 +17,7 @@ public class EditBudgetData implements Serializable {
     private long projectId;
     private String title;
     private String description;
+    private String note;
     private Money total;
     private String importKey;
     private List<String> tags;

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/details/BudgetDetailsPage.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/details/BudgetDetailsPage.html
@@ -136,6 +136,26 @@
 
                         <div class="col-lg-4 col-xs-6">
                             <!-- small box -->
+                            <a wicket:id="notesLink">
+                                <div class="small-box bg-green">
+                                    <div class="inner">
+                                        <h3>Notes</h3>
+                                        <br/>
+                                        <br/>
+                                    </div>
+                                    <div class="icon">
+                                        <i class="ion ion-clipboard"></i>
+                                    </div>
+                                    <div class="small-box-footer">
+                                        Write notes on the budget and use them in meetings <i
+                                            class="fa fa-arrow-circle-right"></i>
+                                    </div>
+                                </div>
+                            </a>
+                        </div>
+
+                        <div class="col-lg-4 col-xs-6">
+                            <!-- small box -->
                             <a wicket:id="editLink">
                                 <div class="small-box bg-green">
                                     <div class="inner">

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/details/BudgetDetailsPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/details/BudgetDetailsPage.java
@@ -29,6 +29,7 @@ import org.wickedsource.budgeteer.web.pages.budgets.details.highlights.BudgetHig
 import org.wickedsource.budgeteer.web.pages.budgets.edit.EditBudgetPage;
 import org.wickedsource.budgeteer.web.pages.budgets.hours.BudgetHoursPage;
 import org.wickedsource.budgeteer.web.pages.budgets.monthreport.single.SingleBudgetMonthReportPage;
+import org.wickedsource.budgeteer.web.pages.budgets.notes.BudgetNotesPage;
 import org.wickedsource.budgeteer.web.pages.budgets.overview.BudgetsOverviewPage;
 import org.wickedsource.budgeteer.web.pages.budgets.weekreport.single.SingleBudgetWeekReportPage;
 import org.wickedsource.budgeteer.web.pages.contract.details.ContractDetailsPage;
@@ -58,6 +59,7 @@ public class BudgetDetailsPage extends BasePage {
         add(new BookmarkablePageLink<SingleBudgetMonthReportPage>("monthReportLink", SingleBudgetMonthReportPage.class, createParameters(getParameterId())));
         addContractLinks();
         add(new BookmarkablePageLink<BudgetHoursPage>("hoursLink", BudgetHoursPage.class, createParameters(getParameterId())));
+        add(new BookmarkablePageLink<BudgetNotesPage>("notesLink", BudgetNotesPage.class, createParameters(getParameterId())));
         add(createEditLink("editLink"));
 
         Form deleteForm = new ConfirmationForm("deleteForm", this, "confirmation.delete") {

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/notes/BudgetNotesPage.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/notes/BudgetNotesPage.html
@@ -1,0 +1,25 @@
+<wicket:extend>
+    <div class="row">
+        <div class="col-md-12">
+            <div class="box box-primary">
+                <div class="box-header">
+                    <i class="fa fa-list"></i>
+
+                    <h3 class="box-title">Editor</h3>
+
+                    <div class="box-tools pull-right">
+                        <button class="btn btn-default btn-sm" data-widget="collapse"><i
+                                class="fa fa-minus"></i></button>
+                    </div>
+                </div>
+
+                <div class="box-body">
+                    <form wicket:id="form" method="post">
+                        <div wicket:id="feedback"></div>
+                        <textarea wicket:id="editor" rows="20"></textarea>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</wicket:extend>

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/notes/BudgetNotesPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/notes/BudgetNotesPage.java
@@ -1,0 +1,62 @@
+package org.wickedsource.budgeteer.web.pages.budgets.notes;
+
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.apache.wicket.util.string.StringValue;
+import org.wickedsource.budgeteer.service.budget.BudgetService;
+import org.wickedsource.budgeteer.service.budget.EditBudgetData;
+import org.wickedsource.budgeteer.web.Mount;
+import org.wickedsource.budgeteer.web.pages.base.basepage.BasePage;
+import org.wickedsource.budgeteer.web.pages.base.basepage.breadcrumbs.Breadcrumb;
+import org.wickedsource.budgeteer.web.pages.base.basepage.breadcrumbs.BreadcrumbsModel;
+import org.wickedsource.budgeteer.web.pages.budgets.BudgetNameModel;
+import org.wickedsource.budgeteer.web.pages.budgets.details.BudgetDetailsPage;
+import org.wickedsource.budgeteer.web.pages.budgets.notes.form.BudgetNotesForm;
+import org.wickedsource.budgeteer.web.pages.budgets.overview.BudgetsOverviewPage;
+import org.wickedsource.budgeteer.web.pages.dashboard.DashboardPage;
+
+import static org.wicketstuff.lazymodel.LazyModel.from;
+import static org.wicketstuff.lazymodel.LazyModel.model;
+
+@Mount("budgets/notes/${id}")
+public class BudgetNotesPage extends BasePage {
+
+    @SpringBean
+    private BudgetService service;
+
+    /**
+     * Load the budget to edit and add a form to the view
+     *
+     * @param pageParameters PageParameters object
+     */
+    public BudgetNotesPage(PageParameters pageParameters) {
+        super(pageParameters);
+
+        EditBudgetData budgetData = service.loadBudgetToEdit(getBudgetId());
+        Form<EditBudgetData> form = new BudgetNotesForm("form", model(from(budgetData)));
+        add(form);
+    }
+
+    @Override
+    protected BreadcrumbsModel getBreadcrumbsModel() {
+        BreadcrumbsModel model = new BreadcrumbsModel(DashboardPage.class, BudgetsOverviewPage.class);
+        model.addBreadcrumb(new Breadcrumb(BudgetDetailsPage.class, getPageParameters(), new BudgetNameModel(getParameterId())));
+        model.addBreadcrumb(new Breadcrumb(BudgetNotesPage.class, getPageParameters(), getString("breadcrumb.title")));
+        return model;
+    }
+
+    /**
+     * Returns the ID of the selected budget
+     *
+     * @return ID of the selected budget
+     */
+    private long getBudgetId() {
+        StringValue value = getPageParameters().get("id");
+        if (value == null || value.isEmpty() || value.isNull()) {
+            return 0L;
+        } else {
+            return value.toLong();
+        }
+    }
+}

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/notes/BudgetNotesPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/notes/BudgetNotesPage.java
@@ -25,6 +25,13 @@ public class BudgetNotesPage extends BasePage {
     @SpringBean
     private BudgetService service;
 
+    public BudgetNotesPage() {
+        super();
+
+        Form<EditBudgetData> form = new BudgetNotesForm("form");
+        add(form);
+    }
+
     /**
      * Load the budget to edit and add a form to the view
      *

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/notes/BudgetNotesPage.properties
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/notes/BudgetNotesPage.properties
@@ -1,0 +1,2 @@
+breadcrumb.title=Notes
+page.title=Notes

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/notes/form/BudgetNotesForm.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/notes/form/BudgetNotesForm.java
@@ -1,0 +1,73 @@
+package org.wickedsource.budgeteer.web.pages.budgets.notes.form;
+
+import org.apache.wicket.injection.Injector;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.form.TextArea;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.wickedsource.budgeteer.service.budget.BudgetService;
+import org.wickedsource.budgeteer.service.budget.EditBudgetData;
+import org.wickedsource.budgeteer.web.components.customFeedback.CustomFeedbackPanel;
+import wicket.contrib.tinymce4.TinyMceBehavior;
+import wicket.contrib.tinymce4.settings.TinyMCESettings;
+import wicket.contrib.tinymce4.settings.Toolbar;
+
+import static org.wicketstuff.lazymodel.LazyModel.from;
+import static org.wicketstuff.lazymodel.LazyModel.model;
+
+public class BudgetNotesForm extends Form<EditBudgetData> {
+
+    @SpringBean
+    private BudgetService service;
+
+    public BudgetNotesForm(String id, IModel<EditBudgetData> model) {
+        super(id, model);
+        Injector.get().inject(this);
+        addComponents();
+    }
+
+    /**
+     * Add all components to the view.
+     * The editor with settings and a CustomFeedbackPanel are added.
+     */
+    private void addComponents() {
+        TinyMCESettings settings = new TinyMCESettings(TinyMCESettings.Theme.modern);
+
+        // The names of the plugins are stored in a string array and then added to the settings in a for-each loop.
+        String plugins = "advlist autolink autosave link image lists charmap print preview hr anchor pagebreak spellchecker " +
+                "searchreplace wordcount visualblocks visualchars code nonbreaking " +
+                "table contextmenu directionality textcolor paste fullpage colorpicker save";
+        String[] pluginNames = plugins.split(" ");
+        for (String name : pluginNames)
+            settings.addPlugins(name);
+
+        // The toolbars for the editor are added to the settings.
+        settings.setMenuBar(false);
+        settings.addToolbar(new Toolbar("toolbar1",
+                "newdocument save print spellchecker fullpage | undo redo | cut copy paste | searchreplace | formatselect fontselect fontsizeselect"));
+        settings.addToolbar(new Toolbar("toolbar2",
+                "forecolor backcolor | bold italic underline strikethrough | bullist numlist | alignleft aligncenter alignright alignjustify | outdent indent blockquote | link unlink anchor image code"));
+        settings.addToolbar(new Toolbar("toolbar3",
+                "table | hr removeformat | subscript superscript | charmap | ltr rtl | visualchars visualblocks nonbreaking pagebreak restoredraft"));
+
+        TextArea<String> textArea = new TextArea<>("editor", model(from(getModel()).getNote()));
+        textArea.add(new TinyMceBehavior(settings));
+        add(textArea);
+
+        add(new CustomFeedbackPanel("feedback"));
+    }
+
+    /**
+     * When the user presses the save button or CTRL+S, the note is saved and a feedback is displayed.
+     */
+    @Override
+    protected void onSubmit() {
+        try {
+            service.saveBudget(getModelObject());
+            this.success("Changes successfully saved.");
+        } catch (DataIntegrityViolationException e) {
+            this.error("Changes could not be saved.");
+        }
+    }
+}

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/notes/form/BudgetNotesForm.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/notes/form/BudgetNotesForm.java
@@ -4,10 +4,13 @@ import org.apache.wicket.injection.Injector;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.TextArea;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.wickedsource.budgeteer.service.budget.BudgetService;
 import org.wickedsource.budgeteer.service.budget.EditBudgetData;
+import org.wickedsource.budgeteer.web.BudgeteerSession;
+import org.wickedsource.budgeteer.web.ClassAwareWrappingModel;
 import org.wickedsource.budgeteer.web.components.customFeedback.CustomFeedbackPanel;
 import wicket.contrib.tinymce4.TinyMceBehavior;
 import wicket.contrib.tinymce4.settings.TinyMCESettings;
@@ -17,6 +20,11 @@ import static org.wicketstuff.lazymodel.LazyModel.from;
 import static org.wicketstuff.lazymodel.LazyModel.model;
 
 public class BudgetNotesForm extends Form<EditBudgetData> {
+
+    public BudgetNotesForm(String id){
+        super(id, new ClassAwareWrappingModel<>(Model.of(new EditBudgetData(BudgeteerSession.get().getProjectId())), EditBudgetData.class));
+        addComponents();
+    }
 
     @SpringBean
     private BudgetService service;

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/notes/form/BudgetNotesForm.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/notes/form/BudgetNotesForm.java
@@ -63,11 +63,16 @@ public class BudgetNotesForm extends Form<EditBudgetData> {
      */
     @Override
     protected void onSubmit() {
-        try {
-            service.saveBudget(getModelObject());
-            this.success("Changes successfully saved.");
-        } catch (DataIntegrityViolationException e) {
-            this.error("Changes could not be saved.");
+
+        if (getModelObject().getNote().getBytes().length > 1024 * 10) {
+            this.error("The note is too large to be saved.");
+        } else {
+            try {
+                service.saveBudget(getModelObject());
+                this.success("Changes successfully saved.");
+            } catch (DataIntegrityViolationException e) {
+                this.error("Changes could not be saved.");
+            }
         }
     }
 }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/notes/form/BudgetNotesForm.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/notes/form/BudgetNotesForm.java
@@ -32,10 +32,10 @@ public class BudgetNotesForm extends Form<EditBudgetData> {
      * The editor with settings and a CustomFeedbackPanel are added.
      */
     private void addComponents() {
-        TinyMCESettings settings = new TinyMCESettings(TinyMCESettings.Theme.modern);
+        TinyMCESettings settings = new TinyMCESettings(TinyMCESettings.Theme.modern, TinyMCESettings.Language.en);
 
         // The names of the plugins are stored in a string array and then added to the settings in a for-each loop.
-        String plugins = "advlist autolink autosave link image lists charmap print preview hr anchor pagebreak spellchecker " +
+        String plugins = "advlist autolink autosave link image lists charmap print preview hr anchor pagebreak " +
                 "searchreplace wordcount visualblocks visualchars code nonbreaking " +
                 "table contextmenu directionality textcolor paste fullpage colorpicker save";
         String[] pluginNames = plugins.split(" ");
@@ -45,11 +45,11 @@ public class BudgetNotesForm extends Form<EditBudgetData> {
         // The toolbars for the editor are added to the settings.
         settings.setMenuBar(false);
         settings.addToolbar(new Toolbar("toolbar1",
-                "newdocument save print spellchecker fullpage | undo redo | cut copy paste | searchreplace | formatselect fontselect fontsizeselect"));
+                "newdocument save print fullpage | undo redo | cut copy paste | searchreplace | formatselect fontselect fontsizeselect"));
         settings.addToolbar(new Toolbar("toolbar2",
-                "forecolor backcolor | bold italic underline strikethrough | bullist numlist | alignleft aligncenter alignright alignjustify | outdent indent blockquote | link unlink anchor image code"));
+                "removeformat | forecolor backcolor | bold italic underline strikethrough | bullist numlist | alignleft aligncenter alignright alignjustify | outdent indent blockquote"));
         settings.addToolbar(new Toolbar("toolbar3",
-                "table | hr removeformat | subscript superscript | charmap | ltr rtl | visualchars visualblocks nonbreaking pagebreak restoredraft"));
+                "table link unlink image | hr pagebreak | visualchars visualblocks"));
 
         TextArea<String> textArea = new TextArea<>("editor", model(from(getModel()).getNote()));
         textArea.add(new TinyMceBehavior(settings));

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/service/budget/BudgetServiceTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/service/budget/BudgetServiceTest.java
@@ -112,6 +112,7 @@ class BudgetServiceTest extends ServiceTestTemplate {
         Assertions.assertEquals(budget.getImportKey(), data.getImportKey());
         Assertions.assertEquals(budget.getName(), data.getTitle());
         Assertions.assertEquals(budget.getId(), data.getId());
+        Assertions.assertEquals(budget.getNote(), data.getNote());
     }
 
     @Test
@@ -128,6 +129,7 @@ class BudgetServiceTest extends ServiceTestTemplate {
         Assertions.assertEquals(data.getTags(), mapEntitiesToTags(budget.getTags()));
         Assertions.assertEquals(data.getTitle(), budget.getName());
         Assertions.assertEquals(data.getTotal(), budget.getTotal());
+        Assertions.assertEquals(data.getNote(), budget.getNote());
         Assertions.assertNull(data.getContract());
     }
 

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/budgets/notes/BudgetNotesPageTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/pages/budgets/notes/BudgetNotesPageTest.java
@@ -1,0 +1,18 @@
+package org.wickedsource.budgeteer.web.pages.budgets.notes;
+
+import org.junit.jupiter.api.Test;
+import org.wickedsource.budgeteer.web.AbstractWebTestTemplate;
+
+public class BudgetNotesPageTest extends AbstractWebTestTemplate {
+
+    @Test
+    void render() {
+        getTester().assertRenderedPage(BudgetNotesPage.class);
+    }
+
+    @Override
+    protected void setupTest() {
+        BudgetNotesPage page = new BudgetNotesPage();
+        getTester().startPage(page);
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,7 @@ reflections_version = 0.9.10
 #
 wicket_spring_version=7.6.0
 wicketstuff_lazymodel_version=7.6.0
+wicketstuff_tinymce4_version=7.6.0
 wicketcharts_version=3.1.0
 #
 slf4j_version = 1.7.21


### PR DESCRIPTION
Notes can be added to a budget using a WYSIQYG editor.

Maybe a version history could be added to keep track of who edited which note and when.

WYSIQYG editor is TinyMCE4 with [WicketStuff](https://github.com/wicketstuff/core/tree/master/tinymce4-parent).