### PR TITLE
WIP: Deployment of the Budgeteer to Artifactory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,3 +29,19 @@ jobs:
           path: ~/artifacts/junit
       - store_artifacts:
           path: ~/artifacts
+  deployment:
+      steps:
+      - type: deploy
+          name: "Deploy snapshot to artifactory"
+        command: |
+          if [ "${CIRCLE_BRANCH}" == "test_deploy" ];
+            then ./gradlew budgeteer-web-interface:artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER
+                  -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM;
+          fi
+      - type: deploy
+          name: "Deploy to bintray"
+        command: |
+          if [ "${CIRCLE_BRANCH}" == "master" ];
+            then ./gradlew budgeteer-web-interface:bintrayUpload -x test -Dbintray.user=$BINTRAY_USER
+                  -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM;
+          fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
               if [ "${CIRCLE_BRANCH}" == "test_deploy" ];
               then ./gradlew budgeteer-web-interface:artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER
               -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM;
-          fi
+              fi
       - run:
           name: Deploy to bintray
           command:
@@ -40,7 +40,7 @@ jobs:
               if [ "${CIRCLE_BRANCH}" == "master" ];
               then ./gradlew budgeteer-web-interface:bintrayUpload -x test -Dbintray.user=$BINTRAY_USER
               -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM;
-          fi
+              fi
       - store_test_results:
           path: ~/artifacts/junit
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,20 +27,18 @@ jobs:
             find . -type f -regex ".*/build/libs/.*jar" -exec cp {} ~/artifacts/ \;
       - run:
           name: Deploy snapshot to artifactory
-          command:
-            - >
-              if [ "${CIRCLE_BRANCH}" == "test_deploy" ];
-              then ./gradlew budgeteer-web-interface:artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER
-              -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM;
-              fi
+          command: |
+              if [ "${CIRCLE_BRANCH}" == "test_deploy" ]; \
+              then ./gradlew budgeteer-web-interface:artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER \
+              -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM; \
+              fi \
       - run:
           name: Deploy to bintray
-          command:
-            - >
-              if [ "${CIRCLE_BRANCH}" == "master" ];
-              then ./gradlew budgeteer-web-interface:bintrayUpload -x test -Dbintray.user=$BINTRAY_USER
-              -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM;
-              fi
+          command: |
+              if [ "${CIRCLE_BRANCH}" == "master" ]; \
+              then ./gradlew budgeteer-web-interface:bintrayUpload -x test -Dbintray.user=$BINTRAY_USER \
+              -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM; \
+              fi \
       - store_test_results:
           path: ~/artifacts/junit
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           command: ./gradlew --stacktrace --console=plain test
       - run:
           name: Save test results
-          command:
+          command: |
             mkdir -p ~/artifacts/junit/
             find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/artifacts/junit/ \;
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,14 +26,14 @@ jobs:
             find . -type f -regex ".*/build/libs/.*war" -exec cp {} ~/artifacts/ \;
             find . -type f -regex ".*/build/libs/.*jar" -exec cp {} ~/artifacts/ \;
       - run:
-          name: "Deploy snapshot to artifactory"
+          name: Deploy snapshot to artifactory
           command: |
           if [ "${CIRCLE_BRANCH}" == "test_deploy" ];
           then ./gradlew budgeteer-web-interface:artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER
           -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM;
           fi
       - run:
-          name: "Deploy to bintray"
+          name: Deploy to bintray
           command: |
           if [ "${CIRCLE_BRANCH}" == "master" ];
           then ./gradlew budgeteer-web-interface:bintrayUpload -x test -Dbintray.user=$BINTRAY_USER

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           command: ./gradlew --stacktrace --console=plain test
       - run:
           name: Save test results
-          command: |
+          command:
             mkdir -p ~/artifacts/junit/
             find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/artifacts/junit/ \;
           when: always
@@ -27,17 +27,19 @@ jobs:
             find . -type f -regex ".*/build/libs/.*jar" -exec cp {} ~/artifacts/ \;
       - run:
           name: Deploy snapshot to artifactory
-          command: |
-          if [ "${CIRCLE_BRANCH}" == "test_deploy" ];
-          then ./gradlew budgeteer-web-interface:artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER
-          -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM;
+          command:
+            - >
+              if [ "${CIRCLE_BRANCH}" == "test_deploy" ];
+              then ./gradlew budgeteer-web-interface:artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER
+              -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM;
           fi
       - run:
           name: Deploy to bintray
-          command: |
-          if [ "${CIRCLE_BRANCH}" == "master" ];
-          then ./gradlew budgeteer-web-interface:bintrayUpload -x test -Dbintray.user=$BINTRAY_USER
-          -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM;
+          command:
+            - >
+              if [ "${CIRCLE_BRANCH}" == "master" ];
+              then ./gradlew budgeteer-web-interface:bintrayUpload -x test -Dbintray.user=$BINTRAY_USER
+              -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM;
           fi
       - store_test_results:
           path: ~/artifacts/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,6 @@ jobs:
           command: |
             find . -type f -regex ".*/build/libs/.*war" -exec cp {} ~/artifacts/ \;
             find . -type f -regex ".*/build/libs/.*jar" -exec cp {} ~/artifacts/ \;
-      - store_test_results:
-          path: ~/artifacts/junit
-      - store_artifacts:
-          path: ~/artifacts
       - run:
           name: "Deploy snapshot to artifactory"
           command: |
@@ -43,3 +39,7 @@ jobs:
           then ./gradlew budgeteer-web-interface:bintrayUpload -x test -Dbintray.user=$BINTRAY_USER
           -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM;
           fi
+      - store_test_results:
+          path: ~/artifacts/junit
+      - store_artifacts:
+          path: ~/artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,21 +25,21 @@ jobs:
           command: |
             find . -type f -regex ".*/build/libs/.*war" -exec cp {} ~/artifacts/ \;
             find . -type f -regex ".*/build/libs/.*jar" -exec cp {} ~/artifacts/ \;
-      - run:
-          name: Deploy snapshot to artifactory
-          command: |
-              if [ "${CIRCLE_BRANCH}" == "test_deploy" ]; \
-              then ./gradlew budgeteer-web-interface:artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER \
-              -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM; \
-              fi \
-      - run:
-          name: Deploy to bintray
-          command: |
-              if [ "${CIRCLE_BRANCH}" == "master" ]; \
-              then ./gradlew budgeteer-web-interface:bintrayUpload -x test -Dbintray.user=$BINTRAY_USER \
-              -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM; \
-              fi \
       - store_test_results:
           path: ~/artifacts/junit
       - store_artifacts:
           path: ~/artifacts
+      - run:
+          name: Deploy snapshot to artifactory
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "test_deploy" ]; \
+            then ./gradlew budgeteer-web-interface:artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER \
+            -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM; \
+            fi \
+      - run:
+          name: Deploy to bintray
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; \
+            then ./gradlew budgeteer-web-interface:bintrayUpload -x test -Dbintray.user=$BINTRAY_USER \
+            -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM; \
+            fi \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,19 +29,17 @@ jobs:
           path: ~/artifacts/junit
       - store_artifacts:
           path: ~/artifacts
-  deployment:
-      steps:
-      - type: deploy
+      - run:
           name: "Deploy snapshot to artifactory"
-        command: |
+          command: |
           if [ "${CIRCLE_BRANCH}" == "test_deploy" ];
-            then ./gradlew budgeteer-web-interface:artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER
-                  -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM;
+          then ./gradlew budgeteer-web-interface:artifactoryPublish -x test -Dsnapshot=true -Dbintray.user=$BINTRAY_USER
+          -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM;
           fi
-      - type: deploy
+      - run:
           name: "Deploy to bintray"
-        command: |
+          command: |
           if [ "${CIRCLE_BRANCH}" == "master" ];
-            then ./gradlew budgeteer-web-interface:bintrayUpload -x test -Dbintray.user=$BINTRAY_USER
-                  -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM;
+          then ./gradlew budgeteer-web-interface:bintrayUpload -x test -Dbintray.user=$BINTRAY_USER
+          -Dbintray.key=$BINTRAY_KEY -Dbuild.number=$CIRCLE_BUILD_NUM;
           fi

--- a/budgeteer-web-interface/build.gradle
+++ b/budgeteer-web-interface/build.gradle
@@ -6,6 +6,8 @@ buildscript {
     }
 
     dependencies {
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:latest.release"
         classpath group: 'org.springframework.boot', name: 'spring-boot-gradle-plugin', version: "${spring_boot_version}"
         classpath group: 'org.springframework', name: 'springloaded', version: "${springloaded_version}"
     }
@@ -13,6 +15,10 @@ buildscript {
 
 apply plugin: 'war'
 apply plugin: 'org.springframework.boot'
+apply plugin: "com.jfrog.artifactory"
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish'
+
 
 configurations {
     querydslapt
@@ -199,5 +205,121 @@ idea {
                 </facet>
             </component>'''
         it.asNode().append(new XmlParser().parseText(springFacet))
+    }
+}
+
+//=============================
+//Bintray/Artifactory Configuration
+
+ext {
+    bintrayUser = System.getProperty("bintray.user")
+    bintrayKey = System.getProperty("bintray.key")
+    buildNumber = System.getProperty("build.number")
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+javadoc.failOnError = false
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}
+
+def pomConfig = {
+    licenses {
+        license {
+            name "MIT"
+            url "https://opensource.org/licenses/MIT"
+            distribution "repo"
+        }
+    }
+    developers {
+        developer {
+            id "thombergs"
+            name "Tom Hombergs"
+            email "tom.hombergs@gmail.com"
+        }
+    }
+
+    scm {
+        url "https://github.com/adessoag/budgeteer"
+    }
+}
+
+artifactory {
+    contextUrl = 'http://oss.jfrog.org'
+    publish {
+        repository {
+            repoKey = 'oss-snapshot-local'
+            username = bintrayUser
+            password = bintrayKey
+        }
+        defaults {
+            publications('mavenPublication')
+            publishArtifacts = true
+            publishPom = true
+            properties = [
+                    'build.number': buildNumber,
+                    'build.name'  : project.name
+            ]
+        }
+    }
+    resolve {
+        repoKey = 'jcenter'
+    }
+    clientConfig.info.setBuildNumber(buildNumber)
+    clientConfig.info.setBuildName(project.name)
+}
+
+bintray {
+    user = bintrayUser
+    key = bintrayKey
+    publications = ['mavenPublication']
+
+    pkg {
+        repo = 'budgeteer'
+        name = 'budgeteer'
+        userOrg = 'adesso'
+        licenses = ['MIT']
+        vcsUrl = 'https://github.com/adessoag/budgeteer'
+        version {
+            name = project.version
+            desc = "build ${buildNumber}"
+            released = new Date()
+        }
+    }
+
+    publish = true
+}
+
+publishing {
+    publications {
+        mavenPublication(MavenPublication) {
+            from components.java
+            artifact sourcesJar {
+                classifier "sources"
+            }
+            artifact javadocJar {
+                classifier "javadoc"
+            }
+            groupId 'de.adesso.budgeteer'
+            artifactId project.name
+            version project.version
+            pom.withXml {
+                def root = asNode()
+                root.appendNode('description', 'Budgeteer')
+                root.appendNode('name', project.name)
+                root.appendNode('url', 'https://github.com/adessoag/budgeteer')
+                root.children().last() + pomConfig
+            }
+        }
     }
 }

--- a/budgeteer-web-interface/build.gradle
+++ b/budgeteer-web-interface/build.gradle
@@ -211,6 +211,10 @@ idea {
 //=============================
 //Bintray/Artifactory Configuration
 
+// run gradle with "-Dsnapshot=true" to automatically append "-SNAPSHOT" to the version
+version = project.version + (Boolean.valueOf(System.getProperty("snapshot")) ? "-SNAPSHOT" : "")
+sourceCompatibility = 1.8
+
 ext {
     bintrayUser = System.getProperty("bintray.user")
     bintrayKey = System.getProperty("bintray.key")

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ subprojects {
     apply plugin: 'jacoco'
 
 
-
     repositories {
         jcenter()
         mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,14 @@ allprojects {
     version = getBuildVersion('1.0.9.BETA')
 }
 
+
+
 subprojects {
+
     apply plugin: 'java'
     apply plugin: 'jacoco'
+
+
 
     repositories {
         jcenter()


### PR DESCRIPTION
This would be the first step of deployment  automation for the Budgeteer.

How it should work:

 - PRs and commits still get built and tested as usual.
 - Commits to the `master` branch should trigger an upload of a snapshot to http://oss.jfrog.org/oss-snapshot-local/ .
 - Commits to the `release` branch (or something similarly named) should upload a new version straight to bintray.

Currently this will not work because I cannot create a new repository on Bintray, as only Owners and Admins have the permissions to do so. @thombergs, could you create a new repository?
Also, I am actually currently getting a 403 (Forbidden) telling me I am not authorized to upload anything, so maybe the `BINTRAY_USER` and `BINTRAY_KEY` environment variables need to be changed to proper ones as well (although members should have the ability to upload/create packages).