### PR TITLE
[FIX-275] Fixed broken URLs and styling in some pages

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/base/basepage/BasePage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/base/basepage/BasePage.java
@@ -109,7 +109,7 @@ public abstract class BasePage extends WebPage {
                 if (settings.isKeycloakActivated()) {
                     setResponsePage(new SelectProjectWithKeycloakPage());
                 } else {
-                    setResponsePage(new SelectProjectPage(this.getWebPage().getClass(), new PageParameters()));
+                    setResponsePage(new SelectProjectPage(this.getWebPage().getClass(), getPageParameters()));
                 }
             }
         };
@@ -158,7 +158,7 @@ public abstract class BasePage extends WebPage {
     public long getParameterId() {
         StringValue value = getPageParameters().get("id");
         if (value == null || value.isEmpty() || value.isNull()) {
-            return 0l;
+            return 0L;
         } else {
             return value.toLong();
         }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/details/BudgetDetailsPage.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/details/BudgetDetailsPage.html
@@ -1,4 +1,4 @@
-<wicket:extend>
+<wicket:extend xmlns:wicket="http://www.w3.org/1999/xhtml">
     <div class="row">
         <div class="col-md-6">
             <div class="box box-primary">

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/details/BudgetDetailsPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/details/BudgetDetailsPage.java
@@ -35,8 +35,6 @@ import org.wickedsource.budgeteer.web.pages.budgets.weekreport.single.SingleBudg
 import org.wickedsource.budgeteer.web.pages.contract.details.ContractDetailsPage;
 import org.wickedsource.budgeteer.web.pages.dashboard.DashboardPage;
 
-import java.util.concurrent.Callable;
-
 @Mount("budgets/details/${id}")
 public class BudgetDetailsPage extends BasePage {
 
@@ -66,19 +64,13 @@ public class BudgetDetailsPage extends BasePage {
             @Override
             public void onSubmit() {
 
-                setResponsePage(new DeleteDialog(new Callable<Void>() {
-                    @Override
-                    public Void call(){
-                        budgetService.deleteBudget(getParameterId());
-                        setResponsePage(BudgetsOverviewPage.class);
-                        return null;
-                    }
-                }, new Callable<Void>() {
-                    @Override
-                    public Void call(){
-                        setResponsePage(new BudgetDetailsPage(getPageParameters()));
-                        return null;
-                    }
+                setResponsePage(new DeleteDialog(() -> {
+                    budgetService.deleteBudget(getParameterId());
+                    setResponsePage(BudgetsOverviewPage.class);
+                    return null;
+                }, () -> {
+                    setResponsePage(new BudgetDetailsPage(getPageParameters()));
+                    return null;
                 }));
             }
         };

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/overview/table/BudgetOverviewTable.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/overview/table/BudgetOverviewTable.java
@@ -118,16 +118,7 @@ public class BudgetOverviewTable extends Panel {
                 Link clink =  new Link("contractLink") {
                     @Override
                     public void onClick() {
-                        WebPage page = new ContractDetailsPage(ContractDetailsPage.createParameters(item.getModelObject().getContractId())){
-                            @Override
-                            protected BreadcrumbsModel getBreadcrumbsModel() {
-                                BreadcrumbsModel m = breadcrumbsModel;
-                                m.addBreadcrumb(ContractDetailsPage.class,
-                                        ContractDetailsPage.createParameters(item.getModelObject().getContractId()));
-                                return m;
-                            }
-                        };
-                        setResponsePage(page);
+                        setResponsePage(ContractDetailsPage.class, ContractDetailsPage.createParameters(item.getModelObject().getContractId()));
                     }
                 };
                 Label clinkTitle = new Label("contractTitle",model(from(item.getModel()).getContractName()));

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/contract/budgetOverview/BudgetForContractOverviewPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/contract/budgetOverview/BudgetForContractOverviewPage.java
@@ -6,9 +6,11 @@ import org.wickedsource.budgeteer.web.pages.base.basepage.BasePage;
 import org.wickedsource.budgeteer.web.pages.base.basepage.breadcrumbs.BreadcrumbsModel;
 import org.wickedsource.budgeteer.web.pages.budgets.overview.table.BudgetOverviewTable;
 import org.wickedsource.budgeteer.web.pages.budgets.overview.table.FilteredBudgetModelByContract;
+import org.wickedsource.budgeteer.web.pages.contract.details.ContractDetailsPage;
+import org.wickedsource.budgeteer.web.pages.contract.overview.ContractOverviewPage;
 import org.wickedsource.budgeteer.web.pages.dashboard.DashboardPage;
 
-@Mount("budgetsForContract")
+@Mount("/contracts/details/budgets/${id}")
 public class BudgetForContractOverviewPage extends BasePage {
 
     public BudgetForContractOverviewPage(PageParameters pageParameters) {
@@ -19,7 +21,9 @@ public class BudgetForContractOverviewPage extends BasePage {
     @SuppressWarnings("unchecked")
     @Override
     protected BreadcrumbsModel getBreadcrumbsModel() {
-        return new BreadcrumbsModel(DashboardPage.class, BudgetForContractOverviewPage.class);
+        BreadcrumbsModel model =  new BreadcrumbsModel(DashboardPage.class, ContractOverviewPage.class);
+        model.addBreadcrumb(ContractDetailsPage.class, getPageParameters());
+        model.addBreadcrumb(BudgetForContractOverviewPage.class, getPageParameters());
+        return model;
     }
-
 }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/contract/details/ContractDetailsPage.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/contract/details/ContractDetailsPage.html
@@ -1,11 +1,10 @@
-<wicket:extend>
+<wicket:extend xmlns:wicket="http://www.w3.org/1999/xhtml">
     <div class="row">
-        <div class="col-md-6" wicket:id="highlightsPanel">
-
+        <div wicket:id="highlightsPanel">
         </div>
 
-        <div class="col-md-6">
-            <div class="col-md-12">
+        <div class="col-md-12">
+            <div>
                 <div class="box box-primary">
                     <div class="box-header">
                         <i class="fa fa-info-circle"></i>
@@ -13,23 +12,25 @@
                         <h3 class="box-title"><wicket:message key="comparison_diagram"></wicket:message></h3>
 
                         <div class="box-tools pull-right">
-                            <button class="btn btn-default btn-sm" data-widget="collapse"><i
-                                    class="fa fa-minus"></i></button>
+                                <span class="btn btn-default btn-sm" data-widget="collapse">
+                                    <i class="fa fa-minus"></i>
+                                </span>
                         </div>
                     </div>
-                    <div class="box-body" style="height: 320px;">
+                    <div class="box-body" style="height: 390px;">
                   		<canvas wicket:id="comparisonChart"></canvas>
                     </div>
                 </div>
             </div>
-            <div class="col-md-12">
+            <div>
                 <div class="box box-primary">
                     <div class="box-header">
                         <i class="fa fa-info-circle"></i>
                         <h3 class="box-title"><wicket:message key="comparison_table"></wicket:message></h3>
                         <div class="box-tools pull-right">
-                            <button class="btn btn-default btn-sm" data-widget="collapse"><i
-                                    class="fa fa-minus"></i></button>
+                                <span class="btn btn-default btn-sm" data-widget="collapse">
+                                    <i class="fa fa-minus"></i>
+                                </span>
                         </div>
                     </div>
                     <div class="box-body" wicket:id="differenceTable">  </div>

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/contract/details/ContractDetailsPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/contract/details/ContractDetailsPage.java
@@ -3,6 +3,7 @@ package org.wickedsource.budgeteer.web.pages.contract.details;
 import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.SubmitLink;
+import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.markup.html.link.Link;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.spring.injection.annot.SpringBean;
@@ -22,9 +23,6 @@ import org.wickedsource.budgeteer.web.pages.contract.edit.EditContractPage;
 import org.wickedsource.budgeteer.web.pages.contract.overview.ContractOverviewPage;
 import org.wickedsource.budgeteer.web.pages.dashboard.DashboardPage;
 import org.wickedsource.budgeteer.web.pages.invoice.edit.EditInvoicePage;
-import org.wickedsource.budgeteer.web.pages.invoice.overview.InvoiceOverviewPage;
-
-import java.util.concurrent.Callable;
 
 @Mount("contracts/details/${id}")
 public class ContractDetailsPage extends BasePage {
@@ -58,52 +56,23 @@ public class ContractDetailsPage extends BasePage {
                 setResponsePage(page);
             }
         });
-        add(new Link("showInvoiceLink"){
-            @Override
-            public void onClick() {
-                WebPage page = new InvoiceOverviewPage(InvoiceOverviewPage.createParameters(getParameterId())){
-
-                    @Override
-                    protected BreadcrumbsModel getBreadcrumbsModel() {
-                        BreadcrumbsModel m = ContractDetailsPage.this.getBreadcrumbsModel();
-                        m.addBreadcrumb(InvoiceOverviewPage.class, getPageParameters());
-                        return m;
-                    }
-                };
-                setResponsePage(page);
-            }
-        });
+        add(new ExternalLink("showInvoiceLink", "invoices/" + contractModel.getObject().getContractId()));
         add(new Link("showContractLink"){
             @Override
             public void onClick() {
-                WebPage page = new BudgetForContractOverviewPage(BudgetForContractOverviewPage.createParameters(getParameterId())){
-
-                    @Override
-                    protected BreadcrumbsModel getBreadcrumbsModel() {
-                        BreadcrumbsModel m = ContractDetailsPage.this.getBreadcrumbsModel();
-                        m.addBreadcrumb(BudgetForContractOverviewPage.class, BudgetForContractOverviewPage.createParameters(getParameterId()));
-                        return m;
-                    }
-                };
-                setResponsePage(page);
+                setResponsePage(BudgetForContractOverviewPage.class, createParameters(getParameterId()));
             }
         });
         Form deleteForm = new ConfirmationForm("deleteForm", this, "confirmation.delete") {
             @Override
             public void onSubmit() {
-                setResponsePage(new DeleteDialog(new Callable<Void>() {
-                    @Override
-                    public Void call() {
-                        contractService.deleteContract(getParameterId());
-                        setResponsePage(ContractOverviewPage.class);
-                        return null;
-                    }
-                }, new Callable<Void>(){
-                    @Override
-                    public Void call(){
-                        setResponsePage(ContractDetailsPage.class, getPageParameters());
-                        return null;
-                    }
+                setResponsePage(new DeleteDialog(() -> {
+                    contractService.deleteContract(getParameterId());
+                    setResponsePage(ContractOverviewPage.class);
+                    return null;
+                }, () -> {
+                    setResponsePage(ContractDetailsPage.class, getPageParameters());
+                    return null;
                 }));
 
 

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/contract/details/contractDetailChart/ContractDetailChart.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/contract/details/contractDetailChart/ContractDetailChart.java
@@ -1,5 +1,6 @@
 package org.wickedsource.budgeteer.web.pages.contract.details.contractDetailChart;
 
+import de.adesso.wickedcharts.chartjs.ChartConfiguration;
 import de.adesso.wickedcharts.wicket7.chartjs.Chart;
 
 import java.io.Serializable;
@@ -17,6 +18,8 @@ public class ContractDetailChart extends Chart implements Serializable {
     protected void onBeforeRender() {
         super.onBeforeRender();
         // resetting options to force re-rendering with new parameters
-        setChartConfiguration(new ContractDetailChartConfiguration(model));
+        ChartConfiguration chartConfiguration = new ContractDetailChartConfiguration(model);
+        chartConfiguration.getOptions().setMaintainAspectRatio(false);
+        setChartConfiguration(chartConfiguration);
     }
 }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/contract/details/highlights/ContractHighlightsPanel.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/contract/details/highlights/ContractHighlightsPanel.html
@@ -1,94 +1,98 @@
-<wicket:panel>
-    <div class="row">
-        <div class="box box-primary">
-            <div class="box-header" style="cursor: move;">
-                <h3 class="box-title"><wicket:message key="contract.basic.information.header" /></h3>
-                <div class="box-tools pull-right">
-                            <span class="btn btn-default btn-sm" data-widget="collapse">
-                                <i class="fa fa-minus"></i>
-                            </span>
-                </div>
-            </div>
-            <div class="box-body">
-                <div class="row">
-                    <div class="col-lg-6 col-xs-6">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3 wicket:id="name">NAME</h3>
-                            </div>
-                            <wicket:message key="contract.name" />
-                        </div>
-                    </div>
-                    <div class="col-lg-6 col-xs-6">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3 wicket:id="internalNumber">NAME</h3>
-                            </div>
-                            <wicket:message key="contract.internalNumber" />
-                        </div>
-                    </div>
-                    <div class="col-lg-6 col-xs-6">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3 wicket:id="startDate">NAME</h3>
-                            </div>
-                            <wicket:message key="contract.startDate" />
-                        </div>
-                    </div>
-                    <div class="col-lg-6 col-xs-6">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3 wicket:id="type">NAME</h3>
-                            </div>
-                            <wicket:message key="contract.type" />
-                        </div>
-                    </div>
-                    <div class="col-lg-6 col-xs-6">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3 wicket:id="budget">NAME</h3>
-                            </div>
-                            <wicket:message key="contract.budget" />
-                        </div>
+<wicket:panel xmlns:wicket="http://www.w3.org/1999/xhtml">
+    <div>
+        <div class="col-md-6">
+            <div class="box box-primary">
+                <div class="box-header" style="cursor: move;">
+                    <h3 class="box-title"><wicket:message key="contract.basic.information.header" /></h3>
+                    <div class="box-tools pull-right">
+                                <span class="btn btn-default btn-sm" data-widget="collapse">
+                                    <i class="fa fa-minus"></i>
+                                </span>
                     </div>
                 </div>
-                <div class="row">
-                    <div class="col-lg-6 col-xs-6" wicket:id="fileContainer">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3><a wicket:id="file" ></a></h3>
+                <div class="box-body">
+                    <div class="row">
+                        <div class="col-lg-6 col-xs-6">
+                            <div class="showcase bg-aqua">
+                                <div class="inner">
+                                    <h3 wicket:id="name">NAME</h3>
+                                </div>
+                                <wicket:message key="contract.name" />
                             </div>
-                            <wicket:message key="contract.fileLink" />
+                        </div>
+                        <div class="col-lg-6 col-xs-6">
+                            <div class="showcase bg-aqua">
+                                <div class="inner">
+                                    <h3 wicket:id="internalNumber">NAME</h3>
+                                </div>
+                                <wicket:message key="contract.internalNumber" />
+                            </div>
+                        </div>
+                        <div class="col-lg-6 col-xs-6">
+                            <div class="showcase bg-aqua">
+                                <div class="inner">
+                                    <h3 wicket:id="startDate">NAME</h3>
+                                </div>
+                                <wicket:message key="contract.startDate" />
+                            </div>
+                        </div>
+                        <div class="col-lg-6 col-xs-6">
+                            <div class="showcase bg-aqua">
+                                <div class="inner">
+                                    <h3 wicket:id="type">NAME</h3>
+                                </div>
+                                <wicket:message key="contract.type" />
+                            </div>
+                        </div>
+                        <div class="col-lg-6 col-xs-6">
+                            <div class="showcase bg-aqua">
+                                <div class="inner">
+                                    <h3 wicket:id="budget">NAME</h3>
+                                </div>
+                                <wicket:message key="contract.budget" />
+                            </div>
                         </div>
                     </div>
-                    <div class="col-lg-6 col-xs-6" wicket:id="linkContainer">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3><a wicket:id="link" ></a></h3>
+                    <div class="row">
+                        <div class="col-lg-6 col-xs-6" wicket:id="fileContainer">
+                            <div class="showcase bg-aqua">
+                                <div class="inner">
+                                    <h3><a wicket:id="file" ></a></h3>
+                                </div>
+                                <wicket:message key="contract.fileLink" />
                             </div>
-                            <wicket:message key="contract.link" />
+                        </div>
+                        <div class="col-lg-6 col-xs-6" wicket:id="linkContainer">
+                            <div class="showcase bg-aqua">
+                                <div class="inner">
+                                    <h3><a wicket:id="link" ></a></h3>
+                                </div>
+                                <wicket:message key="contract.link" />
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-        <div class="box box-primary">
-            <div class="box-header" style="cursor: move;">
-                <h3 class="box-title"><wicket:message key="contract.additional.information.header" /></h3>
-                <div class="box-tools pull-right">
-                            <span class="btn btn-default btn-sm" data-widget="collapse">
-                                <i class="fa fa-minus"></i>
-                            </span>
+        <div class="col-md-6">
+            <div class="box box-primary">
+                <div class="box-header" style="cursor: move;">
+                    <h3 class="box-title"><wicket:message key="contract.additional.information.header" /></h3>
+                    <div class="box-tools pull-right">
+                                <span class="btn btn-default btn-sm" data-widget="collapse">
+                                    <i class="fa fa-minus"></i>
+                                </span>
+                    </div>
                 </div>
-            </div>
-            <div class="box-body">
-                <div class="row">
-                    <div class="col-lg-6 col-xs-6" wicket:id="additionalInformation">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3 wicket:id="value">NAME</h3>
+                <div class="box-body">
+                    <div class="row">
+                        <div class="col-lg-6 col-xs-6" wicket:id="additionalInformation">
+                            <div class="showcase bg-aqua">
+                                <div class="inner">
+                                    <h3 wicket:id="value">NAME</h3>
+                                </div>
+                                <span wicket:id="key" />
                             </div>
-                            <span wicket:id="key" />
                         </div>
                     </div>
                 </div>

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/details/InvoiceDetailsPage.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/details/InvoiceDetailsPage.html
@@ -1,4 +1,4 @@
-<wicket:extend>
+<wicket:extend xmlns:wicket="http://www.w3.org/1999/xhtml">
     <div class="row">
         <div class="col-md-12" wicket:id="highlightsPanel">
 

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/details/InvoiceDetailsPage.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/details/InvoiceDetailsPage.html
@@ -5,7 +5,7 @@
         </div>
     </div>
 
-    <div class="row">
+    <div>
         <div class="col-md-12">
             <div class="box box-primary">
                 <div class="box-header" style="cursor: move;">

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/details/InvoiceDetailsPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/details/InvoiceDetailsPage.java
@@ -43,7 +43,6 @@ public class InvoiceDetailsPage extends BasePage {
         add(deleteForm);
     }
 
-
     @Override
     protected BreadcrumbsModel getBreadcrumbsModel() {
         BreadcrumbsModel model = new BreadcrumbsModel(DashboardPage.class, ContractDetailsPage.class);

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/details/highlights/InvoiceHighlightsPanel.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/details/highlights/InvoiceHighlightsPanel.html
@@ -1,5 +1,5 @@
 <wicket:panel xmlns:wicket="http://www.w3.org/1999/xhtml">
-    <div class="row">
+    <div>
         <div class="col-md-12">
             <div class="box box-primary">
                 <div class="box-header" style="cursor: move;">

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/details/highlights/InvoiceHighlightsPanel.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/details/highlights/InvoiceHighlightsPanel.html
@@ -1,112 +1,112 @@
-<wicket:panel>
+<wicket:panel xmlns:wicket="http://www.w3.org/1999/xhtml">
     <div class="row">
-        <div class="box box-primary">
-            <div class="box-header" style="cursor: move;">
-                <h3 class="box-title"><wicket:message key="invoice.basic.information.header" /></h3>
-                <div class="box-tools pull-right">
-                            <span class="btn btn-default btn-sm" data-widget="collapse">
-                                <i class="fa fa-minus"></i>
-                            </span>
+        <div class="col-md-12">
+            <div class="box box-primary">
+                <div class="box-header" style="cursor: move;">
+                    <h3 class="box-title"><wicket:message key="invoice.basic.information.header" /></h3>
+                    <div class="box-tools pull-right">
+                                <span class="btn btn-default btn-sm" data-widget="collapse">
+                                    <i class="fa fa-minus"></i>
+                                </span>
+                    </div>
+                </div>
+                <div class="box-body">
+                    <div class="row">
+                        <div class="col-lg-6 col-xs-6">
+                            <div class="showcase bg-aqua">
+                                <div class="inner">
+                                    <h3 wicket:id="name">NAME</h3>
+                                </div>
+                                <wicket:message key="invoice.name" />
+                            </div>
+                        </div>
+                        <div class="col-lg-6 col-xs-6">
+                            <div class="showcase bg-aqua">
+                                <div class="inner">
+                                    <h3 wicket:id="contractName">Contract name</h3>
+                                </div>
+                                <wicket:message key="invoice.contract.name" />
+                            </div>
+                        </div>
+                        <div class="col-lg-6 col-xs-6">
+                            <div class="showcase bg-aqua">
+                                <div class="inner">
+                                    <h3 wicket:id="internalNumber">internalNumber</h3>
+                                </div>
+                                <wicket:message key="invoice.internalNumber" />
+                            </div>
+                        </div>
+                        <div class="col-lg-6 col-xs-6">
+                            <div class="showcase bg-aqua">
+                                <div class="inner">
+                                    <h3 wicket:id="year">year</h3>
+                                </div>
+                                <wicket:message key="invoice.year" />
+                            </div>
+                        </div>
+                        <div class="col-lg-6 col-xs-6">
+                            <div class="showcase bg-aqua">
+                                <div class="inner">
+                                    <h3 wicket:id="month">month</h3>
+                                </div>
+                                <wicket:message key="invoice.month" />
+                            </div>
+                        </div>
+                        <div class="col-lg-6 col-xs-6">
+                            <div class="showcase bg-aqua">
+                                <div class="inner">
+                                    <h3 wicket:id="sum">sum</h3>
+                                </div>
+                                <wicket:message key="invoice.sum" />
+                            </div>
+                        </div>
+                        <div class="col-lg-6 col-xs-6">
+                            <div class="showcase bg-aqua">
+                                <div class="inner">
+                                    <h3 wicket:id="paid">paid</h3>
+                                </div>
+                                <wicket:message key="invoice.paid" />
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-lg-6 col-xs-6" wicket:id="fileContainer">
+                                <div class="showcase bg-aqua">
+                                    <div class="inner">
+                                        <h3><a wicket:id="file" ></a></h3>
+                                    </div>
+                                    <wicket:message key="invoice.fileLink" />
+                                </div>
+                            </div>
+                            <div class="col-lg-6 col-xs-6" wicket:id="linkContainer">
+                                <div class="showcase bg-aqua">
+                                    <div class="inner">
+                                        <h3><a wicket:id="link" ></a></h3>
+                                    </div>
+                                    <wicket:message key="invoice.link" />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
-            <div class="box-body">
-                <div class="row">
-                    <div class="col-lg-6 col-xs-6">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3 wicket:id="name">NAME</h3>
-                            </div>
-                            <wicket:message key="invoice.name" />
-                        </div>
-                    </div>
-                    <div class="col-lg-6 col-xs-6">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3 wicket:id="contractName">Contract name</h3>
-                            </div>
-                            <wicket:message key="invoice.contract.name" />
-                        </div>
-                    </div>
-                    <div class="col-lg-6 col-xs-6">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3 wicket:id="internalNumber">internalNumber</h3>
-                            </div>
-                            <wicket:message key="invoice.internalNumber" />
-                        </div>
-                    </div>
-                    <div class="col-lg-6 col-xs-6">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3 wicket:id="year">year</h3>
-                            </div>
-                            <wicket:message key="invoice.year" />
-                        </div>
-                    </div>
-                    <div class="col-lg-6 col-xs-6">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3 wicket:id="month">month</h3>
-                            </div>
-                            <wicket:message key="invoice.month" />
-                        </div>
-                    </div>
-                    <div class="col-lg-6 col-xs-6">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3 wicket:id="sum">sum</h3>
-                            </div>
-                            <wicket:message key="invoice.sum" />
-                        </div>
-                    </div>
-                    <div class="col-lg-6 col-xs-6">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3 wicket:id="paid">paid</h3>
-                            </div>
-                            <wicket:message key="invoice.paid" />
-                        </div>
-                    </div>
-
-
-                </div>
-                <div class="row">
-                    <div class="col-lg-6 col-xs-6" wicket:id="fileContainer">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3><a wicket:id="file" ></a></h3>
-                            </div>
-                            <wicket:message key="invoice.fileLink" />
-                        </div>
-                    </div>
-                    <div class="col-lg-6 col-xs-6" wicket:id="linkContainer">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3><a wicket:id="link" ></a></h3>
-                            </div>
-                            <wicket:message key="invoice.link" />
-                        </div>
+            <div class="box box-primary">
+                <div class="box-header" style="cursor: move;">
+                    <h3 class="box-title"><wicket:message key="invoice.additional.information.header" /></h3>
+                    <div class="box-tools pull-right">
+                                <span class="btn btn-default btn-sm" data-widget="collapse">
+                                    <i class="fa fa-minus"></i>
+                                </span>
                     </div>
                 </div>
-            </div>
-        </div>
-        <div class="box box-primary">
-            <div class="box-header" style="cursor: move;">
-                <h3 class="box-title"><wicket:message key="invoice.additional.information.header" /></h3>
-                <div class="box-tools pull-right">
-                            <span class="btn btn-default btn-sm" data-widget="collapse">
-                                <i class="fa fa-minus"></i>
-                            </span>
-                </div>
-            </div>
-            <div class="box-body">
-                <div class="row">
-                    <div class="col-lg-6 col-xs-6" wicket:id="additionalInformation">
-                        <div class="showcase bg-aqua">
-                            <div class="inner">
-                                <h3 wicket:id="value">NAME</h3>
+                <div class="box-body">
+                    <div class="row">
+                        <div class="col-lg-6 col-xs-6" wicket:id="additionalInformation">
+                            <div class="showcase bg-aqua">
+                                <div class="inner">
+                                    <h3 wicket:id="value">NAME</h3>
+                                </div>
+                                <span wicket:id="key" />
                             </div>
-                            <span wicket:id="key" />
                         </div>
                     </div>
                 </div>

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/edit/EditInvoicePage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/edit/EditInvoicePage.java
@@ -10,25 +10,20 @@ import org.wickedsource.budgeteer.service.invoice.InvoiceService;
 import org.wickedsource.budgeteer.web.Mount;
 import org.wickedsource.budgeteer.web.pages.base.dialogpage.DialogPageWithBacklink;
 import org.wickedsource.budgeteer.web.pages.invoice.edit.form.EditInvoiceForm;
-import org.wickedsource.budgeteer.web.pages.invoice.overview.InvoiceOverviewPage;
 
 import static org.wicketstuff.lazymodel.LazyModel.from;
 import static org.wicketstuff.lazymodel.LazyModel.model;
 
-@Mount({"invoices/edit/${invoiceId}/${id}", "invoices/edit/${contractId}"})
+@Mount("/invoices/edit/${invoiceId}/#{contractId}")
 public class EditInvoicePage extends DialogPageWithBacklink {
 
     @SpringBean
     private InvoiceService service;
 
-    public EditInvoicePage(PageParameters parameters){
-        this(parameters, InvoiceOverviewPage.class, parameters);
-    }
-
     public EditInvoicePage(PageParameters parameters, Class<? extends WebPage> backlinkPage, PageParameters backlinkParameters) {
         super(parameters, backlinkPage, backlinkParameters);
         InvoiceBaseData invoiceBaseData;
-        if(getInvoiceId() == 0l){
+        if(getInvoiceId() == 0L){
             invoiceBaseData = service.getEmptyInvoiceModel(getContractId());
         } else {
             invoiceBaseData = service.getInvoiceById(getInvoiceId());
@@ -55,7 +50,7 @@ public class EditInvoicePage extends DialogPageWithBacklink {
     private long getIdByName(String name) {
         StringValue value = getPageParameters().get(name);
         if (value == null || value.isEmpty() || value.isNull()) {
-            return 0l;
+            return 0L;
         } else {
             return value.toLong();
         }
@@ -69,12 +64,8 @@ public class EditInvoicePage extends DialogPageWithBacklink {
 
     public static PageParameters createNewInvoiceParameters(long contractId) {
         PageParameters parameters = new PageParameters();
+        parameters.add("invoiceId", 0L);
         parameters.add("contractId", contractId);
         return parameters;
     }
-
-
-
-
-
 }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/overview/InvoiceOverviewPage.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/overview/InvoiceOverviewPage.html
@@ -1,4 +1,4 @@
-<wicket:extend>
+<wicket:extend xmlns:wicket="http://www.w3.org/1999/xhtml">
     <div class="row">
         <div class="col-md-12">
             <div class="box box-primary">

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/overview/InvoiceOverviewPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/overview/InvoiceOverviewPage.java
@@ -8,13 +8,16 @@ import org.wickedsource.budgeteer.service.invoice.InvoiceService;
 import org.wickedsource.budgeteer.web.BudgeteerSession;
 import org.wickedsource.budgeteer.web.Mount;
 import org.wickedsource.budgeteer.web.pages.base.basepage.BasePage;
+import org.wickedsource.budgeteer.web.pages.base.basepage.breadcrumbs.Breadcrumb;
 import org.wickedsource.budgeteer.web.pages.base.basepage.breadcrumbs.BreadcrumbsModel;
+import org.wickedsource.budgeteer.web.pages.contract.details.ContractDetailsPage;
+import org.wickedsource.budgeteer.web.pages.contract.overview.ContractOverviewPage;
 import org.wickedsource.budgeteer.web.pages.dashboard.DashboardPage;
 import org.wickedsource.budgeteer.web.pages.invoice.edit.EditInvoicePage;
 import org.wickedsource.budgeteer.web.pages.invoice.overview.table.InvoiceOverviewTable;
 
 
-@Mount({"invoices/${id}", "invoices/"})
+@Mount({"/invoices", "contracts/details/invoices/${id}"})
 public class InvoiceOverviewPage extends BasePage {
 
     @SpringBean
@@ -43,7 +46,7 @@ public class InvoiceOverviewPage extends BasePage {
 
             @Override
             public boolean isVisible() {
-                return getParameterId() != 0l;
+                return getParameterId() != 0L;
             }
         });
     }
@@ -51,6 +54,14 @@ public class InvoiceOverviewPage extends BasePage {
     @SuppressWarnings("unchecked")
     @Override
     protected BreadcrumbsModel getBreadcrumbsModel() {
-        return new BreadcrumbsModel(DashboardPage.class, InvoiceOverviewPage.class);
+        if(getParameterId() != 0L){
+            BreadcrumbsModel model = new BreadcrumbsModel(DashboardPage.class);
+            model.addBreadcrumb(ContractOverviewPage.class);
+            model.addBreadcrumb(ContractDetailsPage.class, getPageParameters());
+            model.addBreadcrumb(InvoiceOverviewPage.class, getPageParameters());
+            return model;
+        }else {
+            return new BreadcrumbsModel(DashboardPage.class, InvoiceOverviewPage.class);
+        }
     }
 }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/overview/table/InvoiceOverviewTable.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/invoice/overview/table/InvoiceOverviewTable.java
@@ -5,6 +5,7 @@ import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
+import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.markup.html.link.Link;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
@@ -21,6 +22,7 @@ import org.wickedsource.budgeteer.web.pages.base.basepage.breadcrumbs.Breadcrumb
 import org.wickedsource.budgeteer.web.pages.contract.details.ContractDetailsPage;
 import org.wickedsource.budgeteer.web.pages.invoice.details.InvoiceDetailsPage;
 import org.wickedsource.budgeteer.web.pages.invoice.edit.EditInvoicePage;
+import org.wickedsource.budgeteer.web.pages.invoice.overview.InvoiceOverviewPage;
 
 import static org.wicketstuff.lazymodel.LazyModel.from;
 import static org.wicketstuff.lazymodel.LazyModel.model;
@@ -47,39 +49,13 @@ public class InvoiceOverviewTable extends Panel{
             @Override
             protected void populateItem(final ListItem<InvoiceBaseData> item) {
                 final long invoiceId = item.getModelObject().getInvoiceId();
-                Link link = new Link("showInvoice"){
-                    @Override
-                    public void onClick() {
-                        WebPage page = new InvoiceDetailsPage(InvoiceDetailsPage.createParameters(invoiceId)){
-
-                            @Override
-                            protected BreadcrumbsModel getBreadcrumbsModel() {
-                                BreadcrumbsModel m = breadcrumbsModel;
-                                m.addBreadcrumb(InvoiceDetailsPage.class, InvoiceDetailsPage.createParameters(invoiceId));
-                                return m;
-                            }
-                        };
-                        setResponsePage(page);
-                    }
-                };
-
+                ExternalLink contractLink;
+                contractLink = new ExternalLink("contractLink", "/contracts/details/" + item.getModelObject().getContractId());
+                ExternalLink link = new ExternalLink("showInvoice", "/invoices/details/" + item.getModelObject().getInvoiceId());
+                contractLink.setContextRelative(false);
+                link.setContextRelative(false);
                 link.add(new Label("invoiceName", model(from(item.getModelObject()).getInvoiceName())));
                 item.add(link);
-                Link contractLink = new Link("contractLink"){
-                    @Override
-                    public void onClick() {
-                        WebPage page = new ContractDetailsPage(ContractDetailsPage.createParameters(item.getModelObject().getContractId())){
-
-                            @Override
-                            protected BreadcrumbsModel getBreadcrumbsModel() {
-                                BreadcrumbsModel m = breadcrumbsModel;
-                                m.addBreadcrumb(ContractDetailsPage.class, ContractDetailsPage.createParameters(item.getModelObject().getContractId()));
-                                return m;
-                            }
-                        };
-                        setResponsePage(page);
-                    }
-                };
                 contractLink.add(new Label("contractName", model(from(item.getModelObject()).getContractName())));
                 item.add(contractLink);
                 item.add(new Label("internalNumber", model(from(item.getModelObject()).getInternalNumber())));
@@ -96,8 +72,13 @@ public class InvoiceOverviewTable extends Panel{
                         item.add(new Label("invoiceRowText", item.getModelObject().getValue()));
                     }
                 });
-                item.add(new BookmarkablePageLink<EditInvoicePage>("editLink", EditInvoicePage.class, EditInvoicePage.createEditInvoiceParameters(invoiceId)));
-            }
+                item.add(new Link("editLink"){
+                    @Override
+                    public void onClick() {
+                        setResponsePage(new EditInvoicePage(EditInvoicePage.createEditInvoiceParameters(invoiceId), this.getWebPage().getClass(), this.getPage().getPageParameters()));
+                    }
+                });
+            };
         });
         table.add(new ListView<String>("footerRow", model(from(data).getFooter()) ) {
             @Override

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/selectproject/SelectProjectPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/user/selectproject/SelectProjectPage.java
@@ -97,9 +97,9 @@ public class SelectProjectPage extends DialogPageWithBacklink {
                 return projectService.getDefaultProjectForUser(BudgeteerSession.get().getLoggedInUser().getId());
             }
         };
-        final Form<ProjectBaseData> form = new Form<ProjectBaseData>("chooseProjectForm", defaultProjectModel);
+        final Form<ProjectBaseData> form = new Form<>("chooseProjectForm", defaultProjectModel);
 
-        DropDownChoice<ProjectBaseData> choice = new DropDownChoice<ProjectBaseData>("projectChoice", form.getModel(), new ProjectsForUserModel(BudgeteerSession.get().getLoggedInUser().getId()), new ProjectChoiceRenderer());
+        DropDownChoice<ProjectBaseData> choice = new DropDownChoice<>("projectChoice", form.getModel(), new ProjectsForUserModel(BudgeteerSession.get().getLoggedInUser().getId()), new ProjectChoiceRenderer());
         choice.setRequired(true);
         choice.add(new OnChangeAjaxBehavior() {
             @Override
@@ -129,8 +129,6 @@ public class SelectProjectPage extends DialogPageWithBacklink {
                 setResponsePage(DashboardPage.class);
             }
         };
-
-
         form.add(markProjectAsDefault);
         form.add(goButton);
         return form;


### PR DESCRIPTION
 - Fixed a bug that made the invoices page inaccessible when accesing it like this : `BudgetOverviewPage -> Contract (on any table entry) -> Show Invoices`
 - Fixed a bug that caused an Exception when switching the Budget Display Unit or return from the SwitchProject menu : `ContractOverviewPage -> Contract Details -> Show Invoices` and  `BudgetOverviewPage -> Contract (on any table entry)`
 - Fixed a bug that caused the user to always land on the Dashboard page (along with an exception) when returning from the Select/Switch Project page (on some pages, such as those with id's in their parameters).
 - Fixed the URLs for the EditInvoicePage
 - Adjusted the styling of the ContractDetailsPage (made the chart and table full-width, this should make them more readable) and InvoiceDetailsPage as it was a bit off

Unfortunately, these fixes come at a cost. Some breadcrumbs (not all, some have actually been corrected) will now be wrong. This is of course not very nice, but in my opinion,
it is better than having Exceptions thrown at users at random.

This fixes issue #275.