### PR TITLE
save person repository from db error when work records sum to zero

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/person/PersonBaseDataBean.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/person/PersonBaseDataBean.java
@@ -13,10 +13,13 @@ public class PersonBaseDataBean implements Serializable {
 
     private Date lastBookedDate;
 
-    public PersonBaseDataBean(Long id, String name, Long averageDailyRateInCents, Date lastBookedDate) {
+    public PersonBaseDataBean(Long id, String name, Long valuedMinutes, Long valuedRate, Date lastBookedDate) {
         this.id = id;
         this.name = name;
-        this.averageDailyRateInCents = averageDailyRateInCents;
+        if (valuedRate == 0L)
+            this.averageDailyRateInCents = 0L;
+        else
+            this.averageDailyRateInCents = valuedMinutes / valuedRate;
         this.lastBookedDate = lastBookedDate;
     }
 

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/person/PersonDetailDataBean.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/person/PersonDetailDataBean.java
@@ -18,10 +18,13 @@ public class PersonDetailDataBean {
 
     private Long budgetBurnedInCents;
 
-    public PersonDetailDataBean(Long id, String name, Long averageDailyRateInCents, Date firstBookedDate, Date lastBookedDate, Double hoursBooked, Long budgetBurnedInCents) {
+    public PersonDetailDataBean(Long id, String name, Long valuedMinutes, Long valuedRate, Date firstBookedDate, Date lastBookedDate, Double hoursBooked, Long budgetBurnedInCents) {
         this.id = id;
         this.name = name;
-        this.averageDailyRateInCents = averageDailyRateInCents;
+        if (valuedRate == 0L)
+            this.averageDailyRateInCents = 0L;
+        else
+            this.averageDailyRateInCents = valuedMinutes / valuedRate;
         this.firstBookedDate = firstBookedDate;
         this.lastBookedDate = lastBookedDate;
         this.hoursBooked = hoursBooked;

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/person/PersonRepository.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/person/PersonRepository.java
@@ -11,13 +11,13 @@ public interface PersonRepository extends CrudRepository<PersonEntity, Long> {
 
     List<PersonEntity> findByProjectIdOrderByNameAsc(long projectId);
 
-    @Query("select new org.wickedsource.budgeteer.persistence.person.PersonBaseDataBean(p.id, p.name, sum(r.minutes * r.dailyRate) / sum(r.minutes), max(r.date)) from PersonEntity p left join p.workRecords r where p.project.id=:projectId group by p.id, p.name order by p.name")
+    @Query("select new org.wickedsource.budgeteer.persistence.person.PersonBaseDataBean(p.id, p.name, sum(r.minutes * r.dailyRate), sum(r.minutes), max(r.date)) from PersonEntity p left join p.workRecords r where p.project.id=:projectId group by p.id, p.name order by p.name")
     List<PersonBaseDataBean> findBaseDataByProjectId(@Param("projectId") long projectId);
 
-    @Query("select new org.wickedsource.budgeteer.persistence.person.PersonBaseDataBean(p.id, p.name, sum(r.minutes * r.dailyRate) / sum(r.minutes), max(r.date)) from PersonEntity p left join p.workRecords r where p.id=:personId group by p.id, p.name order by p.name")
+    @Query("select new org.wickedsource.budgeteer.persistence.person.PersonBaseDataBean(p.id, p.name, sum(r.minutes * r.dailyRate), sum(r.minutes), max(r.date)) from PersonEntity p left join p.workRecords r where p.id=:personId group by p.id, p.name order by p.name")
     PersonBaseDataBean findBaseDataByPersonId(@Param("personId") long personId);
 
-    @Query("select new org.wickedsource.budgeteer.persistence.person.PersonDetailDataBean(p.id, p.name, sum(r.minutes * r.dailyRate) / sum(r.minutes), min(r.date), max(r.date), sum(r.minutes) / 60.0, sum(r.minutes * r.dailyRate) / 60 / 8) from PersonEntity p left join p.workRecords r where p.id=:personId group by p.id, p.name order by p.name")
+    @Query("select new org.wickedsource.budgeteer.persistence.person.PersonDetailDataBean(p.id, p.name, sum(r.minutes * r.dailyRate), sum(r.minutes), min(r.date), max(r.date), sum(r.minutes) / 60.0, sum(r.minutes * r.dailyRate) / 60 / 8) from PersonEntity p left join p.workRecords r where p.id=:personId group by p.id, p.name order by p.name")
     PersonDetailDataBean findDetailDataByPersonId(@Param("personId") long personId);
 
     @Query("select p from PersonEntity p left join fetch p.dailyRates r left join fetch r.budget where p.id=:personId")
@@ -27,6 +27,6 @@ public interface PersonRepository extends CrudRepository<PersonEntity, Long> {
     @Query("delete from PersonEntity p where p.project.id = :projectId")
     void deleteByProjectId(@Param("projectId") long projectId);
 
-    @Query("select new org.wickedsource.budgeteer.persistence.person.PersonBaseDataBean(p.id, p.name, sum(r.minutes * r.dailyRate) / sum(r.minutes), max(r.date)) from PersonEntity p left join p.workRecords r where r.budget.id = :budgetId group by p.id, p.name order by p.name")
+    @Query("select new org.wickedsource.budgeteer.persistence.person.PersonBaseDataBean(p.id, p.name, sum(r.minutes * r.dailyRate), sum(r.minutes), max(r.date)) from PersonEntity p left join p.workRecords r where r.budget.id = :budgetId group by p.id, p.name order by p.name")
     List<PersonBaseDataBean> findBaseDataByBudgetId(@Param("budgetId") long budgetId);
 }

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/service/person/PersonServiceTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/service/person/PersonServiceTest.java
@@ -26,7 +26,7 @@ class PersonServiceTest extends ServiceTestTemplate {
     private PersonRepository personRepository;
 
     @Test
-    void testLoadPeopleBaseData() throws Exception {
+    void testLoadPeopleBaseData() {
         when(personRepository.findBaseDataByProjectId(1L)).thenReturn(Arrays.asList(createPersonBaseDataBean()));
         List<PersonBaseData> data = personService.loadPeopleBaseData(1L);
         Assertions.assertEquals(1, data.size());
@@ -38,7 +38,7 @@ class PersonServiceTest extends ServiceTestTemplate {
 
 
     @Test
-    void testLoadPersonDetailData() throws Exception {
+    void testLoadPersonDetailData() {
         when(personRepository.findDetailDataByPersonId(1L)).thenReturn(createPersonDetailDataBean());
         PersonDetailData data = personService.loadPersonDetailData(1L);
         Assertions.assertEquals("person1", data.getName());
@@ -51,7 +51,7 @@ class PersonServiceTest extends ServiceTestTemplate {
 
 
     @Test
-    void testLoadPersonBaseData() throws Exception {
+    void testLoadPersonBaseData() {
         when(personRepository.findBaseDataByPersonId(1L)).thenReturn(createPersonBaseDataBean());
         PersonBaseData bean = personService.loadPersonBaseData(1L);
         Assertions.assertEquals(Long.valueOf(1), bean.getId());
@@ -61,10 +61,10 @@ class PersonServiceTest extends ServiceTestTemplate {
     }
 
     private PersonBaseDataBean createPersonBaseDataBean() {
-        return new PersonBaseDataBean(1L, "person1", 10000L, fixedDate);
+        return new PersonBaseDataBean(1L, "person1", 500000000L, 50000L, fixedDate);
     }
 
     private PersonDetailDataBean createPersonDetailDataBean() {
-        return new PersonDetailDataBean(1L, "person1", 123456L, fixedDate, fixedDate, 5.0d, 654321L);
+        return new PersonDetailDataBean(1L, "person1", 6172800000L, 50000L, fixedDate, fixedDate, 5.0d, 654321L);
     }
 }


### PR DESCRIPTION
This can happen with cancellation bookings. Anyway, a fatal database error should be prevented any time.
In this case now the weighted minutes default to a zero rate (to give a simple value).

fixes #292