### PR TITLE
[FIX-290] added button for reseting filters to hours pages

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/record/WorkRecordFilter.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/record/WorkRecordFilter.java
@@ -32,6 +32,15 @@ public class WorkRecordFilter implements Serializable {
     @Setter
     private DateRange dateRange;
 
+    /***
+     * Clear the selected filter options.
+     */
+    public void clearFilter() {
+        personList = new LinkedList<>();
+        budgetList = new LinkedList<>();
+        dateRange = null;
+    }
+
     public WorkRecordFilter(long projectId) {
         this.projectId = projectId;
     }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/burntable/BurnTableWithFilter.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/burntable/BurnTableWithFilter.java
@@ -1,10 +1,12 @@
 package org.wickedsource.budgeteer.web.components.burntable;
 
+import org.apache.wicket.Page;
 import org.apache.wicket.markup.html.link.DownloadLink;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.markup.repeater.data.DataView;
 import org.apache.wicket.model.AbstractReadOnlyModel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.wickedsource.budgeteer.service.exports.ExportService;
 import org.wickedsource.budgeteer.service.record.WorkRecordFilter;
 import org.wickedsource.budgeteer.web.components.burntable.filter.FilterPanel;
@@ -23,14 +25,14 @@ public class BurnTableWithFilter extends Panel {
 
     private BurnTable burnTable;
 
-    public BurnTableWithFilter(String id, WorkRecordFilter initialFilter) {
-        this(id, initialFilter, false);
+    public BurnTableWithFilter(String id, WorkRecordFilter initialFilter, Page page, PageParameters pageParameters) {
+        this(id, initialFilter, false, page, pageParameters);
     }
 
-    public BurnTableWithFilter(String id, WorkRecordFilter initialFilter, boolean dailyRateIsEditable) {
+    public BurnTableWithFilter(String id, WorkRecordFilter initialFilter, boolean dailyRateIsEditable, Page page, PageParameters pageParameters) {
         super(id);
 
-        filterPanel = new FilterPanel("filter", initialFilter);
+        filterPanel = new FilterPanel("filter", initialFilter, page, pageParameters);
         add(filterPanel);
 
         FilteredRecordsModel tableModel = new FilteredRecordsModel(initialFilter);

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/burntable/filter/FilterPanel.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/burntable/filter/FilterPanel.html
@@ -3,7 +3,7 @@
         <div class="col-xs-6">
             <div class="col-xs-6" wicket:id="personFilterContainer">
                 <div class="form-group">
-                    <label>Name Filter</label><br />
+                    <label>Name Filter</label><br/>
                     <select wicket:id="personSelect" class="form-control">
                         <option>Tom Hombergs</option>
                         <option>Martha Pfahl</option>
@@ -22,7 +22,7 @@
             </div>
         </div>
         <div class="col-xs-6">
-            <div class="col-xs-8" wicket:id="daterangeFilterContainer">
+            <div class="col-xs-6" wicket:id="daterangeFilterContainer">
                 <div class="form-group">
                     <label>Date Range Filter</label>
 
@@ -35,8 +35,13 @@
                 </div>
             </div>
 
-            <div class="col-xs-4">
+            <div class="col-xs-3">
                 <button class="btn btn-default btn-block" type="submit" style="margin-top:25px">Apply Filter</button>
+            </div>
+            <div class="col-xs-3">
+                <button wicket:id="resetButton" class="btn btn-default btn-block" style="margin-top:25px">Reset
+                    Filters
+                </button>
             </div>
         </div>
     </form>

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/burntable/filter/FilterPanel.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/burntable/filter/FilterPanel.java
@@ -1,11 +1,13 @@
 package org.wickedsource.budgeteer.web.components.burntable.filter;
 
+import org.apache.wicket.Page;
 import org.apache.wicket.event.Broadcast;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.ListMultipleChoice;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.wickedsource.budgeteer.service.budget.BudgetBaseData;
 import org.wickedsource.budgeteer.service.budget.BudgetService;
@@ -15,6 +17,7 @@ import org.wickedsource.budgeteer.service.record.WorkRecordFilter;
 import org.wickedsource.budgeteer.web.BudgeteerSession;
 import org.wickedsource.budgeteer.web.components.budget.BudgetBaseDataChoiceRenderer;
 import org.wickedsource.budgeteer.web.components.daterange.DateRangeInputField;
+import org.wickedsource.budgeteer.web.components.links.ResetFilterLink;
 import org.wickedsource.budgeteer.web.components.multiselect.MultiselectBehavior;
 import org.wickedsource.budgeteer.web.components.person.PersonBaseDataChoiceRenderer;
 import org.wicketstuff.lazymodel.LazyModel;
@@ -40,7 +43,7 @@ public class FilterPanel extends Panel {
     private BudgetService budgetService;
 
     @SuppressWarnings("unchecked")
-    public FilterPanel(String id, WorkRecordFilter filter) {
+    public FilterPanel(String id, WorkRecordFilter filter, Page page, PageParameters pageParameters) {
         super(id, model(from(filter)));
         IModel<WorkRecordFilter> model = (IModel<WorkRecordFilter>) getDefaultModel();
         Form<WorkRecordFilter> form = new Form<WorkRecordFilter>("filterForm", model) {
@@ -52,6 +55,7 @@ public class FilterPanel extends Panel {
         form.add(createPersonFilter("personFilterContainer", form));
         form.add(createBudgetFilter("budgetFilterContainer", form));
         form.add(createDaterangeFilter("daterangeFilterContainer", form));
+        form.add(new ResetFilterLink("resetButton", filter, page, pageParameters));
         add(form);
     }
 
@@ -65,7 +69,7 @@ public class FilterPanel extends Panel {
         container.setVisible(isPersonFilterEnabled());
         LazyModel<List<PersonBaseData>> chosenPersons = model(from(form.getModelObject().getPersonList()));
         List<PersonBaseData> possiblePersonsFromFilter = form.getModelObject().getPossiblePersons();
-        List<PersonBaseData> possiblePersons = possiblePersonsFromFilter.isEmpty() ?  personService.loadPeopleBaseData(BudgeteerSession.get().getProjectId()) : possiblePersonsFromFilter;
+        List<PersonBaseData> possiblePersons = possiblePersonsFromFilter.isEmpty() ? personService.loadPeopleBaseData(BudgeteerSession.get().getProjectId()) : possiblePersonsFromFilter;
         ListMultipleChoice<PersonBaseData> selectedPersons =
                 new ListMultipleChoice<PersonBaseData>("personSelect", chosenPersons,
                         possiblePersons, new PersonBaseDataChoiceRenderer());
@@ -73,7 +77,7 @@ public class FilterPanel extends Panel {
 
         selectedPersons.setRequired(false);
         HashMap<String, String> options = MultiselectBehavior.getRecommendedOptions();
-        options.put("buttonWidth","'250px'");
+        options.put("buttonWidth", "'250px'");
         options.remove("buttonClass");
         selectedPersons.add(new MultiselectBehavior(options));
         container.add(selectedPersons);
@@ -94,7 +98,7 @@ public class FilterPanel extends Panel {
         ListMultipleChoice<BudgetBaseData> selectedBudgets = new ListMultipleChoice<>("budgetSelect", chosenBudgets, possibleBudgets, new BudgetBaseDataChoiceRenderer());
 
         HashMap<String, String> options = MultiselectBehavior.getRecommendedOptions();
-        options.put("buttonWidth","'250px'");
+        options.put("buttonWidth", "'250px'");
         options.remove("buttonClass");
         selectedBudgets.add(new MultiselectBehavior(options));
         selectedBudgets.setRequired(false);

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/links/ResetFilterLink.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/links/ResetFilterLink.java
@@ -1,0 +1,25 @@
+package org.wickedsource.budgeteer.web.components.links;
+
+import org.apache.wicket.Page;
+import org.apache.wicket.markup.html.link.Link;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.wickedsource.budgeteer.service.record.WorkRecordFilter;
+
+public class ResetFilterLink extends Link {
+    private WorkRecordFilter filter;
+    private Page currentPage;
+    private PageParameters currentPageParameters;
+
+    public ResetFilterLink(String id, WorkRecordFilter workRecordFilter, Page page, PageParameters pageParameters) {
+        super(id);
+        this.filter = workRecordFilter;
+        this.currentPage = page;
+        this.currentPageParameters = pageParameters;
+    }
+
+    @Override
+    public void onClick() {
+        filter.clearFilter();
+        setResponsePage(currentPage.getClass(), currentPageParameters);
+    }
+}

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/hours/BudgetHoursPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/hours/BudgetHoursPage.java
@@ -30,7 +30,7 @@ public class BudgetHoursPage extends BasePage {
         filter.getBudgetList().add(new BudgetBaseData(getParameterId(), ""));
         filter.getPossiblePersons().addAll(personService.loadPeopleBaseDataByBudget(getParameterId()));
 
-        BurnTableWithFilter table = new BurnTableWithFilter("burnTable", filter);
+        BurnTableWithFilter table = new BurnTableWithFilter("burnTable", filter, this, parameters);
         table.setBudgetFilterEnabled(false);
         add(table);
     }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/hours/HoursPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/hours/HoursPage.java
@@ -13,7 +13,7 @@ public class HoursPage extends BasePage {
 
     public HoursPage() {
         long projectId = BudgeteerSession.get().getProjectId();
-        BurnTableWithFilter table = new BurnTableWithFilter("burnTable", new WorkRecordFilter(projectId), true);
+        BurnTableWithFilter table = new BurnTableWithFilter("burnTable", new WorkRecordFilter(projectId), true, this, null);
         add(table);
     }
 

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/person/hours/PersonHoursPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/person/hours/PersonHoursPage.java
@@ -30,7 +30,7 @@ public class PersonHoursPage extends BasePage {
         filter.getPersonList().add(new PersonBaseData(getParameterId()));
         filter.getPossibleBudgets().addAll(budgetService.loadBudgetBaseDataByPersonId(getParameterId()));
 
-        BurnTableWithFilter table = new BurnTableWithFilter("burnTable", filter);
+        BurnTableWithFilter table = new BurnTableWithFilter("burnTable", filter, this, parameters);
         table.setPersonFilterEnabled(false);
         add(table);
     }

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/components/burntable/BurnTableWithFilterTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/components/burntable/BurnTableWithFilterTest.java
@@ -1,5 +1,6 @@
 package org.wickedsource.budgeteer.web.components.burntable;
 
+import org.wickedsource.budgeteer.web.pages.hours.HoursPage;
 import org.apache.wicket.util.tester.WicketTester;
 import org.junit.jupiter.api.Test;
 import org.wickedsource.budgeteer.service.record.WorkRecordFilter;
@@ -10,7 +11,7 @@ public class BurnTableWithFilterTest extends AbstractWebTestTemplate {
     @Test
     void render() {
         WicketTester tester = getTester();
-        BurnTableWithFilter table = new BurnTableWithFilter("panel", new WorkRecordFilter(1L));
+        BurnTableWithFilter table = new BurnTableWithFilter("panel", new WorkRecordFilter(1L), new HoursPage(), null);
         tester.startComponentInPage(table);
     }
 

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/components/burntable/FilterPanelTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/web/components/burntable/FilterPanelTest.java
@@ -5,13 +5,14 @@ import org.junit.jupiter.api.Test;
 import org.wickedsource.budgeteer.service.record.WorkRecordFilter;
 import org.wickedsource.budgeteer.web.AbstractWebTestTemplate;
 import org.wickedsource.budgeteer.web.components.burntable.filter.FilterPanel;
+import org.wickedsource.budgeteer.web.pages.hours.HoursPage;
 
 public class FilterPanelTest extends AbstractWebTestTemplate {
 
     @Test
     void render() {
         WicketTester tester = getTester();
-        FilterPanel panel = new FilterPanel("panel", new WorkRecordFilter(1L));
+        FilterPanel panel = new FilterPanel("panel", new WorkRecordFilter(1L), new HoursPage(), null);
         tester.startComponentInPage(panel);
     }
 


### PR DESCRIPTION
Hours Pages (hours of all budget and persons, hours of one selected budget, hours of one selected person):
A button to reset the applied filters is added.
By clicking the button all filters are reseted to their default state.

This fixes #290. 