### PR TITLE
[FIX-289]: typo in templates overview

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/templates/table/TemplatesTable.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/templates/table/TemplatesTable.html
@@ -27,7 +27,7 @@
         <tfoot>
         <tr>
             <th>Name</th>
-            <th>Desription</th>
+            <th>Description</th>
             <th>Type</th>
             <th>Default</th>
             <th></th>

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/templates/table/TemplatesTable.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/templates/table/TemplatesTable.html
@@ -6,7 +6,7 @@
         <thead>
         <tr>
             <th>Name</th>
-            <th>Desription</th>
+            <th>Description</th>
             <th>Type</th>
             <th>Default</th>
             <th></th>


### PR DESCRIPTION
Fixed a typo found in the templates overview.
This fixes #289.