### PR TITLE
[FIX-267] Fix deletion of plan records at import

### DIFF
--- a/budgeteer-resourceplan-importer/src/main/java/org/wickedsource/budgeteer/importer/resourceplan/ResourcePlanImporter.java
+++ b/budgeteer-resourceplan-importer/src/main/java/org/wickedsource/budgeteer/importer/resourceplan/ResourcePlanImporter.java
@@ -51,7 +51,7 @@ public class ResourcePlanImporter implements PlanRecordsImporter {
             List<DateColumn> dateColumns = getDateColumns(sheet);
             int i = FIRST_ENTRY_ROW;
             Row row = sheet.getRow(i);
-            while (row != null && row.getCell(0).getStringCellValue() != null) {
+            while (row != null && row.getCell(0) != null && row.getCell(0).getStringCellValue() != null) {
                 List<ImportedPlanRecord> records = parseRow(row, dateColumns, currencyUnit, skippedRecords);
                 resultList.addAll(records);
                 row = sheet.getRow(++i);
@@ -150,7 +150,7 @@ public class ResourcePlanImporter implements PlanRecordsImporter {
         ExampleFile file = new ExampleFile();
         file.setFileName("resource_plan.xlsx");
         file.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        
+
         try {
             Date date = new Date();
             Calendar calendar = Calendar.getInstance();

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/record/PlanRecordRepository.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/record/PlanRecordRepository.java
@@ -244,8 +244,8 @@ public interface PlanRecordRepository extends CrudRepository<PlanRecordEntity, L
     List<PlanRecordEntity> findByPersonBudgetDate(@Param("personId") long personId, @Param("budgetId") long budgetId, @Param("date") Date date);
 
     @Modifying
-    @Query("delete from PlanRecordEntity r where r.budget.id in ( select b.id from BudgetEntity b where b.project.id = :projectId) AND r.date >= :date")
-    void deleteByProjectIdAndDate(@Param("projectId") long projectId, @Param("date") Date date);
+    @Query("delete from PlanRecordEntity r where r.budget.id in ( select b.id from BudgetEntity b where b.importKey = :importKey) AND r.date >= :date")
+    void deleteByBudgetKeyAndDate(@Param("importKey") String importKey, @Param("date") Date date);
 
     @Override
     @Query("select pr from PlanRecordEntity pr where pr.budget.project.id = :projectId")

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/record/PlanRecordRepository.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/record/PlanRecordRepository.java
@@ -244,8 +244,8 @@ public interface PlanRecordRepository extends CrudRepository<PlanRecordEntity, L
     List<PlanRecordEntity> findByPersonBudgetDate(@Param("personId") long personId, @Param("budgetId") long budgetId, @Param("date") Date date);
 
     @Modifying
-    @Query("delete from PlanRecordEntity r where r.budget.id in ( select b.id from BudgetEntity b where b.importKey = :importKey) AND r.date >= :date")
-    void deleteByBudgetKeyAndDate(@Param("importKey") String importKey, @Param("date") Date date);
+    @Query("delete from PlanRecordEntity r where r.budget.id in ( select b.id from BudgetEntity b where  b.project.id = :projectId AND b.importKey = :importKey) AND r.date >= :date")
+    void deleteByBudgetKeyAndDate(@Param("projectId") long projectId,@Param("importKey") String importKey, @Param("date") Date date);
 
     @Override
     @Query("select pr from PlanRecordEntity pr where pr.budget.project.id = :projectId")

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/imports/PlanRecordDatabaseImporter.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/imports/PlanRecordDatabaseImporter.java
@@ -62,7 +62,7 @@ public class PlanRecordDatabaseImporter extends RecordDatabaseImporter {
             // Select which record to delete for each budget individually
             List<ImportedPlanRecord> budgetRecords = getRecordsOfBudget(name, records);
             Date earliestDate = findEarliestDate(budgetRecords);
-            planRecordRepository.deleteByBudgetKeyAndDate(name, earliestDate);
+            planRecordRepository.deleteByBudgetKeyAndDate(getProjectId(), name, earliestDate);
         }
 
         for (RecordKey key : groupedRecords.keySet()) {


### PR DESCRIPTION
This PR fixes #267. 

Previously, when importing plan records, all old records of the whole project before the earliest date of the imported records  were deleted.
This caused deletion of records of budgets, which weren't included in the import.

Now only the old records of budgets which are contained in the imported records are deleted. 