### PR TITLE
Gradle 5.6.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip


### PR DESCRIPTION
Gradle 5.6.2 is available.

This is sent by @gradleupdate. See https://gradleupdate.appspot.com/adessoAG/budgeteer/status for more.