### PR TITLE
budgetReport: Deletes formula evaluation by apache poi

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/budget/report/BudgetReportService.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/budget/report/BudgetReportService.java
@@ -72,7 +72,6 @@ public class BudgetReportService {
 		writeSummary(wb.getSheetAt(0), overallSummary);
 		writeSummary(wb.getSheetAt(1), monthlySummary);
 
-		XSSFFormulaEvaluator.evaluateAllFormulaCells(wb);
 		return createOutputFile(wb);
 	}
 

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/budget/report/BudgetReportService.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/budget/report/BudgetReportService.java
@@ -1,5 +1,7 @@
 package org.wickedsource.budgeteer.service.budget.report;
 
+import org.apache.poi.ss.formula.eval.NotImplementedException;
+import org.apache.poi.ss.formula.eval.NotImplementedFunctionException;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.xssf.usermodel.XSSFFormulaEvaluator;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
@@ -72,6 +74,11 @@ public class BudgetReportService {
 		writeSummary(wb.getSheetAt(0), overallSummary);
 		writeSummary(wb.getSheetAt(1), monthlySummary);
 
+		try {
+			XSSFFormulaEvaluator.evaluateAllFormulaCells(wb);
+		} catch (NotImplementedException e) {
+			wb.setForceFormulaRecalculation(true);
+		}
 		return createOutputFile(wb);
 	}
 


### PR DESCRIPTION
When creating a budget report, the formulas from the template were evaluated by Apache POI, causing formulas to throw an exception without the support of the framework.
The evaluation is not necessary, because Excel evaluates the formulas when opening the file. That's why we deleted the evaluation by Apache POI.

Fixes #410