### PR TITLE
contract: Allow empty values for additional information fields

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/contract/ContractFieldEntity.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/contract/ContractFieldEntity.java
@@ -1,6 +1,8 @@
 package org.wickedsource.budgeteer.persistence.contract;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.wickedsource.budgeteer.persistence.project.ProjectContractField;
 
 import javax.persistence.*;
@@ -8,6 +10,7 @@ import java.io.Serializable;
 
 @Data
 @Entity
+@NoArgsConstructor
 @Table(name="CONTRACT_FIELD")
 public class ContractFieldEntity implements Serializable{
 
@@ -26,5 +29,10 @@ public class ContractFieldEntity implements Serializable{
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "CONTRACT_ID")
     private ContractEntity contract;
+
+    public ContractFieldEntity(ProjectContractField field, String value) {
+        this.field = field;
+        this.value = value;
+    }
 
 }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/contract/ContractService.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/contract/ContractService.java
@@ -94,8 +94,10 @@ public class ContractService {
             contractEntity.setTaxRate(new BigDecimal(contractBaseData.getTaxRate()));
         }
 
+        // Use LinkedHashMap as backing map implementation to ensure insertion order
         Map<String, ContractFieldEntity> contractFields = contractEntity.getContractFields().stream()
-                .collect(Collectors.toMap(field -> field.getField().getFieldName(), Function.identity()));
+                .collect(Collectors.toMap(field -> field.getField().getFieldName(), Function.identity(), (a, b) -> a,
+                        LinkedHashMap::new));
 
         for (DynamicAttributeField dynamicAttribute : contractBaseData.getContractAttributes()) {
             ContractFieldEntity fieldEntity = contractFields.get(dynamicAttribute.getName().trim());

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/service/contract/ContractServiceTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/service/contract/ContractServiceTest.java
@@ -5,6 +5,7 @@ import com.github.springtestdbunit.annotation.DatabaseOperation;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import org.apache.commons.lang3.time.DateUtils;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,7 +52,7 @@ class ContractServiceTest extends ServiceIntegrationTestTemplate {
     @Test
     @DatabaseSetup("contractTest.xml")
     @DatabaseTearDown(value = "contractTest.xml", type = DatabaseOperation.DELETE_ALL)
-    void testSaveNewContract(){
+    void testSaveNewContract() {
         ContractBaseData testObject = new ContractBaseData();
         testObject.setBudget(MoneyUtil.createMoney(12));
         testObject.setContractId(0);
@@ -78,7 +79,7 @@ class ContractServiceTest extends ServiceIntegrationTestTemplate {
     @Test
     @DatabaseSetup("contractTest.xml")
     @DatabaseTearDown(value = "contractTest.xml", type = DatabaseOperation.DELETE_ALL)
-    void testSaveNewContract2(){
+    void testSaveNewContract2() {
         ContractBaseData testObject = new ContractBaseData();
         testObject.setContractId(0);
         testObject.setProjectId(2);
@@ -103,7 +104,7 @@ class ContractServiceTest extends ServiceIntegrationTestTemplate {
     @Test
     @DatabaseSetup("contractTest.xml")
     @DatabaseTearDown(value = "contractTest.xml", type = DatabaseOperation.DELETE_ALL)
-    void testUpdateContract(){
+    void testUpdateContract() {
         ContractBaseData testObject = service.getContractById(4);
 
         testObject.setBudget(MoneyUtil.createMoney(12));
@@ -128,8 +129,8 @@ class ContractServiceTest extends ServiceIntegrationTestTemplate {
         assertEquals(6, savedContract.getContractAttributes().size());
         for (int i = 0; i < 6; i++) {
             boolean found = false;
-            for(DynamicAttributeField field : savedContract.getContractAttributes()){
-                if(field.getName().equals(field.getValue()) && field.getValue().equals("test" + i)){
+            for (DynamicAttributeField field : savedContract.getContractAttributes()) {
+                if (field.getName().equals(field.getValue()) && field.getValue().equals("test" + i)) {
                     found = true;
                     break;
                 }
@@ -146,7 +147,7 @@ class ContractServiceTest extends ServiceIntegrationTestTemplate {
     @Test
     @DatabaseSetup("contractTest.xml")
     @DatabaseTearDown(value = "contractTest.xml", type = DatabaseOperation.DELETE_ALL)
-    void testUpdateContract1(){
+    void testUpdateContract1() {
         ContractBaseData testObject = service.getContractById(5);
 
         testObject.setBudget(MoneyUtil.createMoney(12));
@@ -172,8 +173,8 @@ class ContractServiceTest extends ServiceIntegrationTestTemplate {
         assertEquals(7, savedContract.getContractAttributes().size());
         for (int i = 0; i < 7; i++) {
             boolean found = false;
-            for(DynamicAttributeField field : savedContract.getContractAttributes()){
-                if(field.getName().equals(field.getValue()) && field.getValue().equals("test" + i)){
+            for (DynamicAttributeField field : savedContract.getContractAttributes()) {
+                if (field.getName().equals(field.getValue()) && field.getValue().equals("test" + i)) {
                     found = true;
                     break;
                 }
@@ -235,7 +236,7 @@ class ContractServiceTest extends ServiceIntegrationTestTemplate {
     private List<DynamicAttributeField> getListOfContractFields() {
         List<DynamicAttributeField> result = new LinkedList<DynamicAttributeField>();
         DynamicAttributeField data = new DynamicAttributeField();
-        for(int i = 0; i < 5; i++) {
+        for (int i = 0; i < 5; i++) {
             data = new DynamicAttributeField();
             data.setName("test" + i);
             data.setValue("test" + i);
@@ -257,7 +258,37 @@ class ContractServiceTest extends ServiceIntegrationTestTemplate {
         assertNull(service.getContractById(3));
     }
 
+    @Test
+    @DatabaseSetup("contractTest.xml")
+    @DatabaseTearDown(value = "contractTest.xml", type = DatabaseOperation.DELETE_ALL)
+    void shouldUpdateAttributeWithEmptyValue() {
+        ContractBaseData testObject = service.getContractById(4);
+        testObject.setContractAttributes(getListOfContractFields());
+        DynamicAttributeField field = testObject.getContractAttributes().get(0);
+        field.setValue(null);
 
+        long newContractId = service.save(testObject);
 
+        ContractBaseData savedContract = service.getContractById(newContractId);
 
+        Assertions.assertThat(savedContract.getContractAttributes())
+                .contains(new DynamicAttributeField(field.getName(), ""));
+    }
+
+    @Test
+    @DatabaseSetup("contractTest.xml")
+    @DatabaseTearDown(value = "contractTest.xml", type = DatabaseOperation.DELETE_ALL)
+    void shouldSaveAttributeWithEmptyValue() {
+        ContractBaseData testObject = service.getContractById(4);
+        testObject.setContractAttributes(getListOfContractFields());
+        DynamicAttributeField field = new DynamicAttributeField("new-key", null);
+        testObject.getContractAttributes().add(field);
+
+        long newContractId = service.save(testObject);
+
+        ContractBaseData savedContract = service.getContractById(newContractId);
+
+        Assertions.assertThat(savedContract.getContractAttributes())
+                .contains(new DynamicAttributeField(field.getName(), ""));
+    }
 }


### PR DESCRIPTION
This also includes a cleanup of the code. Instead of iterating trough
the lists with a nested for-loop, we now create a map with the field
name as a key. This allows us to quickly check if an attribute already
exists, and update it, or create a new one.

EDIT: I have updated the PR so that the order of attributes is guaranteed.

Closes #395