### PR TITLE
person: Fix error when accessing a person details when no records exist

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/person/PersonDetailDataBean.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/person/PersonDetailDataBean.java
@@ -21,7 +21,7 @@ public class PersonDetailDataBean {
     public PersonDetailDataBean(Long id, String name, Long valuedMinutes, Long valuedRate, Date firstBookedDate, Date lastBookedDate, Double hoursBooked, Long budgetBurnedInCents) {
         this.id = id;
         this.name = name;
-        if (valuedRate == 0L)
+        if (valuedRate == null || valuedRate == 0L)
             this.averageDailyRateInCents = 0L;
         else
             this.averageDailyRateInCents = valuedMinutes / valuedRate;


### PR DESCRIPTION
When accessing the details page for a person after all their records
have been deleted a NullPointerException was triggered because the query
in PersonRepository#findDetailDataByPersonId fed the
PersonDetailDataBean constructor null values for valuedMinutes, and
valuedRate, since the table it joins with is empty. As a workaround we
do what is already done in the PersonBaseDataBean constructor. We check
if valuedMinutes is null and, if it is null, default
averageDailyRateInCents to 0.

Fixes #422