### PR TITLE
project-administration: Assign defaultDateRange to model object

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/administration/ProjectAdministrationPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/administration/ProjectAdministrationPage.java
@@ -70,8 +70,10 @@ public class ProjectAdministrationPage extends BasePage {
             }
         };
         form.add(new TextField<String>("projectTitle", model(from(form.getModelObject()).getName())));
-        DateRange defaultDateRange = new DateRange(DateUtil.getBeginOfYear(), DateUtil.getEndOfYear());
-        form.add(new DateRangeInputField("projectStart", model(from(form.getModelObject()).getDateRange()), defaultDateRange, DateRangeInputField.DROP_LOCATION.DOWN));
+        if (form.getModelObject().getDateRange().getStartDate() == null || form.getModelObject().getDateRange().getEndDate() == null) {
+            form.getModelObject().setDateRange(new DateRange(DateUtil.getBeginOfYear(), DateUtil.getEndOfYear()));
+        }
+        form.add(new DateRangeInputField("projectStart", model(from(form.getModelObject()).getDateRange()), DateRangeInputField.DROP_LOCATION.DOWN));
         return form;
     }
 


### PR DESCRIPTION
The defaultDateRange needs to be assigned to the project to display the correct dateRange when saving the form. 
This is caused by the used constructor of DateRangeInputField with the defaultDateRange, which seems to not perform correctly.

Closes #383