### PR TITLE
person-details: Adds defaultDailyRate and minor design changes

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/person/PersonDetailDataBean.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/person/PersonDetailDataBean.java
@@ -1,24 +1,23 @@
 package org.wickedsource.budgeteer.persistence.person;
 
+import lombok.Getter;
+import org.joda.money.Money;
+
 import java.util.Date;
 
+@Getter
 public class PersonDetailDataBean {
 
     private Long id;
-
     private String name;
-
     private Long averageDailyRateInCents;
-
+    private Money defaultDailyRate;
     private Date firstBookedDate;
-
     private Date lastBookedDate;
-
     private Double hoursBooked;
-
     private Long budgetBurnedInCents;
 
-    public PersonDetailDataBean(Long id, String name, Long valuedMinutes, Long valuedRate, Date firstBookedDate, Date lastBookedDate, Double hoursBooked, Long budgetBurnedInCents) {
+    public PersonDetailDataBean(Long id, String name, Long valuedMinutes, Long valuedRate, Date firstBookedDate, Date lastBookedDate, Double hoursBooked, Long budgetBurnedInCents, Money defaultDailyRate) {
         this.id = id;
         this.name = name;
         if (valuedRate == null || valuedRate == 0L)
@@ -29,33 +28,6 @@ public class PersonDetailDataBean {
         this.lastBookedDate = lastBookedDate;
         this.hoursBooked = hoursBooked;
         this.budgetBurnedInCents = budgetBurnedInCents;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public Long getAverageDailyRateInCents() {
-        return averageDailyRateInCents;
-    }
-
-    public Date getFirstBookedDate() {
-        return firstBookedDate;
-    }
-
-    public Date getLastBookedDate() {
-        return lastBookedDate;
-    }
-
-    public Double getHoursBooked() {
-        return hoursBooked;
-    }
-
-    public Long getBudgetBurnedInCents() {
-        return budgetBurnedInCents;
+        this.defaultDailyRate = defaultDailyRate;
     }
 }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/person/PersonRepository.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/person/PersonRepository.java
@@ -17,7 +17,7 @@ public interface PersonRepository extends CrudRepository<PersonEntity, Long> {
     @Query("select new org.wickedsource.budgeteer.persistence.person.PersonBaseDataBean(p.id, p.name, sum(r.minutes * r.dailyRate), sum(r.minutes), max(r.date), p.defaultDailyRate) from PersonEntity p left join p.workRecords r where p.id=:personId group by p.id, p.name, p.defaultDailyRate order by p.name")
     PersonBaseDataBean findBaseDataByPersonId(@Param("personId") long personId);
 
-    @Query("select new org.wickedsource.budgeteer.persistence.person.PersonDetailDataBean(p.id, p.name, sum(r.minutes * r.dailyRate), sum(r.minutes), min(r.date), max(r.date), sum(r.minutes) / 60.0, sum(r.minutes * r.dailyRate) / 60 / 8) from PersonEntity p left join p.workRecords r where p.id=:personId group by p.id, p.name, p.defaultDailyRate order by p.name")
+    @Query("select new org.wickedsource.budgeteer.persistence.person.PersonDetailDataBean(p.id, p.name, sum(r.minutes * r.dailyRate), sum(r.minutes), min(r.date), max(r.date), sum(r.minutes) / 60.0, sum(r.minutes * r.dailyRate) / 60 / 8, p.defaultDailyRate) from PersonEntity p left join p.workRecords r where p.id=:personId group by p.id, p.name, p.defaultDailyRate order by p.name")
     PersonDetailDataBean findDetailDataByPersonId(@Param("personId") long personId);
 
     @Query("select p from PersonEntity p left join fetch p.dailyRates r left join fetch r.budget where p.id=:personId")

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/person/PersonDetailData.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/person/PersonDetailData.java
@@ -10,6 +10,7 @@ public class PersonDetailData {
 
     private String name;
     private Money averageDailyRate;
+    private Money defaultDailyRate;
     private Date firstBookedDate;
     private Date lastBookedDate;
     private Double hoursBooked;

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/person/PersonDetailDataMapper.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/service/person/PersonDetailDataMapper.java
@@ -15,6 +15,7 @@ public class PersonDetailDataMapper extends AbstractMapper<PersonDetailDataBean,
         if (sourceObject.getAverageDailyRateInCents() != null) {
             data.setAverageDailyRate(MoneyUtil.createMoneyFromCents(sourceObject.getAverageDailyRateInCents()));
         }
+        data.setDefaultDailyRate(sourceObject.getDefaultDailyRate());
         data.setLastBookedDate(sourceObject.getLastBookedDate());
         data.setFirstBookedDate(sourceObject.getFirstBookedDate());
         data.setHoursBooked(sourceObject.getHoursBooked());

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/person/details/PersonDetailsPage.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/person/details/PersonDetailsPage.html
@@ -88,7 +88,7 @@
                                         <i class="ion ion-stats-bars"></i>
                                     </div>
                                     <div class="small-box-footer">
-                                        Report of budget burned by this person aggregated by month<i
+                                        Report of budget burned by this person aggregated by month <i
                                             class="fa fa-arrow-circle-right"></i>
                                     </div>
                                 </div>

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/person/details/highlights/PersonHighlightsPanel.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/person/details/highlights/PersonHighlightsPanel.html
@@ -1,6 +1,6 @@
 <wicket:panel>
     <div class="row">
-        <div class="col-lg-6 col-xs-6">
+        <div class="col-lg-12 col-xs-12">
             <div class="showcase bg-aqua">
                 <div class="inner">
                     <h3 wicket:id="name">NAME</h3>
@@ -8,12 +8,22 @@
                 Name
             </div>
         </div>
+    </div>
+    <div class="row">
         <div class="col-lg-6 col-xs-6">
             <div class="showcase bg-aqua">
                 <div class="inner">
                     <h3 wicket:id="avgDailyRate">€1.250,48</h3>
                 </div>
                 Avg. Daily Rate
+            </div>
+        </div>
+        <div class="col-lg-6 col-xs-6">
+            <div class="showcase bg-aqua">
+                <div class="inner">
+                    <h3 wicket:id="defaultDailyRate">€100,00</h3>
+                </div>
+                Default Daily Rate
             </div>
         </div>
     </div>

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/person/details/highlights/PersonHighlightsPanel.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/person/details/highlights/PersonHighlightsPanel.java
@@ -3,6 +3,8 @@ package org.wickedsource.budgeteer.web.pages.person.details.highlights;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.GenericPanel;
 import org.apache.wicket.model.IModel;
+import org.wickedsource.budgeteer.MoneyUtil;
+import org.wickedsource.budgeteer.service.DateUtil;
 import org.wickedsource.budgeteer.service.person.PersonDetailData;
 import org.wickedsource.budgeteer.web.components.datelabel.DateLabel;
 import org.wickedsource.budgeteer.web.components.money.MoneyLabel;
@@ -22,8 +24,11 @@ public class PersonHighlightsPanel extends GenericPanel<PersonDetailData> {
         super.onInitialize();
         add(new Label("name", nullsafeModel(model(from(getModel()).getName()))));
         add(new MoneyLabel("avgDailyRate", model(from(getModel()).getAverageDailyRate()), true));
-        add(new DateLabel("firstBookedDate", model(from(getModel()).getFirstBookedDate())));
-        add(new DateLabel("lastBookedDate", model(from(getModel()).getLastBookedDate())));
+        add(getModelObject().getDefaultDailyRate() == null ?
+                new Label("defaultDailyRate", getString("nullString"))
+                : new MoneyLabel("defaultDailyRate", model(from(getModel()).getDefaultDailyRate()), true));
+        add(new DateLabel("firstBookedDate", model(from(getModel()).getFirstBookedDate()), true));
+        add(new DateLabel("lastBookedDate", model(from(getModel()).getLastBookedDate()), true));
         add(new Label("hoursBooked", nullsafeDoubleModel(model(from(getModel()).getHoursBooked()))));
         add(new MoneyLabel("budgetBurned_net", model(from(getModel()).getBudgetBurned()), true));
     }

--- a/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/service/person/PersonServiceTest.java
+++ b/budgeteer-web-interface/src/test/java/org/wickedsource/budgeteer/service/person/PersonServiceTest.java
@@ -49,6 +49,7 @@ class PersonServiceTest extends ServiceTestTemplate {
         Assertions.assertEquals(fixedDate, data.getFirstBookedDate());
         Assertions.assertEquals(MoneyUtil.createMoneyFromCents(654321L), data.getBudgetBurned());
         Assertions.assertEquals(5.0d, data.getHoursBooked(), 0.1d);
+        Assertions.assertEquals(MoneyUtil.createMoney(100L), data.getDefaultDailyRate());
     }
 
 
@@ -68,6 +69,6 @@ class PersonServiceTest extends ServiceTestTemplate {
     }
 
     private PersonDetailDataBean createPersonDetailDataBean() {
-        return new PersonDetailDataBean(1L, "person1", 6172800000L, 50000L, fixedDate, fixedDate, 5.0d, 654321L);
+        return new PersonDetailDataBean(1L, "person1", 6172800000L, 50000L, fixedDate, fixedDate, 5.0d, 654321L, MoneyUtil.createMoney(100L));
     }
 }


### PR DESCRIPTION
This pull request changes the style of the person details page. The person highlights now include the defaultDailyRate and the year of the dates are displayed with four digits.

Note: This Pull Request is based on #413, so first the PR #413 must be merged and then a rebase is necessary.

Closes #441