### PR TITLE
Misleading information project administration

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/daterange/DateRangeInputField.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/daterange/DateRangeInputField.java
@@ -9,39 +9,41 @@ import org.wickedsource.budgeteer.service.DateRange;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
+import java.util.Map;
 
 public class DateRangeInputField extends TextField<DateRange> {
 
-    public static enum DROP_LOCATION {UP, DOWN}
+    public enum DropLocation {UP, DOWN}
 
-    public DateRangeInputField(String id, IModel<DateRange> model, DROP_LOCATION drop_location) {
-        this(id, model, null, drop_location);
+    public DateRangeInputField(String id, IModel<DateRange> model, DropLocation dropLocation) {
+        this(id, model, null, dropLocation);
     }
 
     public DateRangeInputField(String id, IModel<DateRange> model) {
-        this(id, model, null, DROP_LOCATION.DOWN);
+        this(id, model, null, DropLocation.DOWN);
     }
 
     /**
      * Creates a DateRangeInputField which displays the given dateRange when opened
      */
-    public DateRangeInputField(String id, IModel<DateRange> model, DateRange defaultRange, DROP_LOCATION drop_location) {
+    public DateRangeInputField(String id, IModel<DateRange> model, DateRange defaultRange, DropLocation dropLocation) {
         super(id, model);
-        HashMap<String, String> options = new HashMap<String, String>();
+        Map<String, String> options = new HashMap<>();
         if(defaultRange != null && (defaultRange.getStartDate() != null || defaultRange.getEndDate() != null)){
             DateFormat format = new SimpleDateFormat("dd.MM.yyyy");
-            options.put("format","'dd.MM.YYYY'");
             DateRange modelObject = model.getObject();
             if(defaultRange.getStartDate() != null){
-                options.put("startDate", "'"+format.format(modelObject.getStartDate() == null ? defaultRange.getStartDate() : modelObject.getStartDate())+"'");
+                options.put("startDate", String.format("'%s'", format.format(modelObject.getStartDate() == null ? defaultRange.getStartDate() : modelObject.getStartDate())));
             }
             if(defaultRange.getEndDate() != null){
-                options.put("endDate", "'"+format.format(modelObject.getEndDate() == null ? defaultRange.getEndDate() : modelObject.getEndDate())+"'");
+                options.put("endDate", String.format("'%s'", format.format(modelObject.getEndDate() == null ? defaultRange.getEndDate() : modelObject.getEndDate())));
             }
         }
-        options.put("drops", drop_location == DROP_LOCATION.DOWN ? "'down'" : "'up'");
-        options.put("'linkedCalendars'", "false");
-        super.add(new DateRangePickerBehavior(options));
+        options.put("format","'DD.MM.YYYY'");
+        options.put("enableEmptyDate", "true");
+        options.put("drops", dropLocation == DropLocation.DOWN ? "'down'" : "'up'");
+        options.put("linkedCalendars", "false");
+        super.add(new DateRangePickerBehavior(options, true));
     }
 
 

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/daterange/DateRangePickerBehavior.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/daterange/DateRangePickerBehavior.java
@@ -10,19 +10,23 @@ import org.apache.wicket.request.resource.PackageResourceReference;
 import org.apache.wicket.request.resource.ResourceReference;
 import org.wickedsource.budgeteer.web.BudgeteerReferences;
 
-import java.util.HashMap;
 import java.util.Map;
 
-
 public class DateRangePickerBehavior extends Behavior{
-    private HashMap<String, String> options;
+    private final Map<String, String> options;
+    private final boolean clearable;
 
     /**
     * Implements the DateRangePicker
     * @param options @see <a href="http://www.daterangepicker.com/#options">Options</a>
     */
-    public DateRangePickerBehavior(HashMap<String, String> options){
+    public DateRangePickerBehavior(Map<String, String> options){
+        this(options, false);
+    }
+
+    public DateRangePickerBehavior(Map<String, String> options, boolean clearable){
         this.options = options;
+        this.clearable = clearable;
     }
 
     @Override
@@ -41,20 +45,26 @@ public class DateRangePickerBehavior extends Behavior{
     }
 
     public String getScript(Component component) {
-        StringBuilder script = new StringBuilder("$('#"+component.getMarkupId()+"').daterangepicker(");
+        StringBuilder script = new StringBuilder(String.format("$('#%s').daterangepicker(", component.getMarkupId()));
         if(options != null && ! options.isEmpty()){
             script.append("{");
             int index = 1;
             for(Map.Entry<String, String> entry : options.entrySet()) {
-                script.append(entry.getKey() + ": " + entry.getValue());
-                if(index < options.size()){
+                script.append(entry.getKey()).append(": ").append(entry.getValue());
+                if(index < options.size() || clearable){
                     script.append(",");
                 }
                 index++;
             }
+            if (clearable) {
+                script.append("locale: { cancelLabel: 'Clear' }");
+            }
             script.append("}");
         }
         script.append(");");
+        if (clearable) {
+            script.append(String.format("$('#%s').on('cancel.daterangepicker', function(ev, picker) { $(this).val(''); })", component.getMarkupId()));
+        }
         return script.toString();
     }
 }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/daterange/daterangepicker.js
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/components/daterange/daterangepicker.js
@@ -428,7 +428,13 @@
         //
 
         if (this.element.is('input') && !this.singleDatePicker) {
-            this.element.val(this.startDate.format(this.locale.format) + this.locale.separator + this.endDate.format(this.locale.format));
+            if (this.enableEmptyDate && (this.element.val() == '' || !this.startDate.isValid())) {
+                this.element.val('');
+            } else {
+                this.element.val(this.startDate.format(this.locale.format) +
+                  this.locale.separator +
+                  this.endDate.format(this.locale.format));
+            }
             this.element.trigger('change');
         } else if (this.element.is('input')) {
             if(this.enableEmptyDate && (this.element.val() == '' || !this.startDate.isValid())){

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/administration/ProjectAdministrationPage.html
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/administration/ProjectAdministrationPage.html
@@ -15,7 +15,8 @@
                         </div>
                         <div class="col-md-8">
                             <label for="projectStart" class="col-md-3" >Begin and End of Project: </label>
-                            <input id="projectStart" name="projectStart" class="col-md-6" type="text" wicket:id="projectStart">
+                            <input id="projectStart" name="projectStart" class="col-md-6" type="text" value="" wicket:id="projectStart"
+                            placeholder="No timeframe set"/>
                         </div>
                         <input type="submit" value="Save" class="btn btn-primary btn-flat">
                     </div>

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/administration/ProjectAdministrationPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/administration/ProjectAdministrationPage.java
@@ -71,7 +71,7 @@ public class ProjectAdministrationPage extends BasePage {
         };
         form.add(new TextField<String>("projectTitle", model(from(form.getModelObject()).getName())));
         DateRange defaultDateRange = new DateRange(DateUtil.getBeginOfYear(), DateUtil.getEndOfYear());
-        form.add(new DateRangeInputField("projectStart", model(from(form.getModelObject()).getDateRange()), defaultDateRange, DateRangeInputField.DROP_LOCATION.DOWN));
+        form.add(new DateRangeInputField("projectStart", model(from(form.getModelObject()).getDateRange()), defaultDateRange, DateRangeInputField.DropLocation.DOWN));
         return form;
     }
 

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/administration/ProjectAdministrationPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/administration/ProjectAdministrationPage.java
@@ -70,8 +70,7 @@ public class ProjectAdministrationPage extends BasePage {
             }
         };
         form.add(new TextField<String>("projectTitle", model(from(form.getModelObject()).getName())));
-        DateRange defaultDateRange = new DateRange(DateUtil.getBeginOfYear(), DateUtil.getEndOfYear());
-        form.add(new DateRangeInputField("projectStart", model(from(form.getModelObject()).getDateRange()), defaultDateRange, DateRangeInputField.DropLocation.DOWN));
+        form.add(new DateRangeInputField("projectStart", model(from(form.getModelObject()).getDateRange()), null, DateRangeInputField.DropLocation.DOWN));
         return form;
     }
 

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/overview/report/form/BudgetReportForm.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/overview/report/form/BudgetReportForm.java
@@ -55,9 +55,9 @@ public class BudgetReportForm extends Form<ReportMetaInformation> {
         add(new NotificationListPanel("notificationList", new BudgetReportNotificationModel()));
         add(new CustomFeedbackPanel("feedback"));
         add(new DateRangeInputField("monthlyRange", model(from(getModel()).getMonthlyTimeRange()),
-                DateRangeInputField.DROP_LOCATION.DOWN));
+                DateRangeInputField.DropLocation.DOWN));
         add(new DateRangeInputField("overallRange", model(from(getModel()).getOverallTimeRange()),
-                DateRangeInputField.DROP_LOCATION.DOWN));
+                DateRangeInputField.DropLocation.DOWN));
         DropDownChoice<Template> templateDropDown = new DropDownChoice<Template>("template", model(from(getModel()).getTemplate()),
                 new LoadableDetachableModel<List<? extends Template>>() {
 

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/person/edit/personrateform/PersonEditPanel.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/person/edit/personrateform/PersonEditPanel.java
@@ -1,7 +1,6 @@
 package org.wickedsource.budgeteer.web.pages.person.edit.personrateform;
 
 import org.apache.wicket.AttributeModifier;
-import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.extensions.markup.html.form.select.IOptionRenderer;
 import org.apache.wicket.extensions.markup.html.form.select.Select;
 import org.apache.wicket.extensions.markup.html.form.select.SelectOptions;
@@ -49,7 +48,7 @@ public abstract class PersonEditPanel extends Panel {
         rateField = new MoneyTextField("rateField", new Model<>(data.getRate()));
         rateField.setRequired(true);
 
-        dateRangeField = new DateRangeInputField("dateRangeField", new Model<>(data.getDateRange()), DateRangeInputField.DROP_LOCATION.UP);
+        dateRangeField = new DateRangeInputField("dateRangeField", new Model<>(data.getDateRange()), DateRangeInputField.DropLocation.UP);
         dateRangeField.setRequired(true);
 
         List<OptionGroup<BudgetBaseData>> possibleBudgets =


### PR DESCRIPTION
This PR allows to display empty dates and clear dates with the `DateRangePickerBehavior` and makes use of it in `ProjectAdministrationPage` to allow for deletion, and to display that no timeframe for the project has been set (instead of the former, and incorrect, start of year to end of year).

Closes #456 