### PR TITLE
Allow deletion of budgets that refer to contracts

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/overview/table/BudgetOverviewTable.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/overview/table/BudgetOverviewTable.java
@@ -160,13 +160,7 @@ public class BudgetOverviewTable extends Panel {
                 };
                 //Creating a separate tooltip is necessary because disabling the button also causes tooltips to disappear.
                 WebMarkupContainer deleteBudgetTooltip = new WebMarkupContainer("deleteBudgetTooltip");
-                if(item.getModelObject().getContractName() != null){
-                    deleteBudgetTooltip.add(new AttributeAppender("style", "cursor: not-allowed;", " "));
-                    deleteBudgetTooltip.add(new AttributeModifier("title", getString("contract.still.exist")));
-                    deleteBudgetButton.setEnabled(false);
-                }else{
-                    deleteBudgetTooltip.add(new AttributeModifier("title", getString("delete.budget")));
-                }
+                deleteBudgetTooltip.add(new AttributeModifier("title", getString("delete.budget")));
                 deleteBudgetTooltip.add(deleteBudgetButton);
                 item.add(deleteBudgetTooltip);
 


### PR DESCRIPTION
This is a fixes #455 by simply removing the code that set the disabled attribute if a contract was set.