### PR TITLE
Fix invalid tags

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/edit/form/EditBudgetForm.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/edit/form/EditBudgetForm.java
@@ -70,15 +70,6 @@ public class EditBudgetForm extends Form<EditBudgetData> {
         TagsTextField tagsField = new TagsTextField("tagsInput", model(from(getModel()).getTags()));
         tagsField.setOutputMarkupId(true);
         add(tagsField);
-        tagsField.add(new AjaxEventBehavior("change") {
-            @SuppressWarnings("unchecked")
-            @Override
-            protected void onEvent(AjaxRequestTarget target) {
-                if (getModelObject().getTags().size() > 0) {
-                    BudgeteerSession.get().getBudgetFilter().getSelectedTags().remove(getModelObject().getTags().remove(0));
-                }
-            }
-        });
         add(new CustomFeedbackPanel("feedback"));
         add(new RequiredTextField<>("name", model(from(getModel()).getTitle())));
         add(new TextField<>("description", model(from(getModel()).getDescription())));

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/edit/tagsfield/TagsConverter.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/edit/tagsfield/TagsConverter.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.util.convert.ConversionException;
 import org.apache.wicket.util.convert.IConverter;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -12,6 +13,9 @@ public class TagsConverter implements IConverter<List<String>> {
 
     @Override
     public List<String> convertToObject(String value, Locale locale) throws ConversionException {
+        if (value == null || value.trim().isEmpty()) {
+            return new ArrayList<>();
+        }
         String[] values = value.split(",");
         return Arrays.asList(values);
     }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/edit/tagsfield/TagsTextField.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/budgets/edit/tagsfield/TagsTextField.java
@@ -20,9 +20,14 @@ public class TagsTextField extends TextField<List<String>> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public <List> IConverter<List> getConverter(Class<List> type) {
-        return (IConverter<List>) new TagsConverter();
+    protected IConverter<?> createConverter(Class<?> type) {
+        return new TagsConverter();
+    }
+
+    @Override
+    public void convertInput() {
+        IConverter<List<String>> converter = getConverter(getType());
+        setConvertedInput(converter.convertToObject(getValue(), getLocale()));
     }
 
     @Override

--- a/budgeteer-web-interface/src/main/resources/db/migration/V1_1_5__RemoveInvalidBudgetTags.sql
+++ b/budgeteer-web-interface/src/main/resources/db/migration/V1_1_5__RemoveInvalidBudgetTags.sql
@@ -1,0 +1,4 @@
+DELETE
+FROM BUDGET_TAG
+WHERE
+    tag = ''


### PR DESCRIPTION
This PR changes `TagsConverter` to properly handle empty input, removes existing workarounds, and adds a migration to remove the invalid data.

Resolves #469.
