### PR TITLE
persistence: Implement the missing GetAuthenticationUserPort

### DIFF
--- a/budgeteer-app/src/test/java/de/adesso/budgeteer/BudgeteerApplicationTest.java
+++ b/budgeteer-app/src/test/java/de/adesso/budgeteer/BudgeteerApplicationTest.java
@@ -1,0 +1,18 @@
+package de.adesso.budgeteer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class BudgeteerApplicationTest {
+
+    @Test
+    void contextLoads() {
+        /* Verify that the context properly loads */
+        Assertions.assertTrue(true);
+    }
+
+}

--- a/budgeteer-app/src/test/resources/application-test.yml
+++ b/budgeteer-app/src/test/resources/application-test.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: 'jdbc:hsqldb:mem:budgeteer'
+    driver-class-name: 'org.hsqldb.jdbcDriver'
+    username: 'sa'
+    password: ''
+  jpa:
+    properties:
+      hibernate:
+        dialect: ''

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/user/UserAdapter.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/user/UserAdapter.java
@@ -1,5 +1,7 @@
 package org.wickedsource.budgeteer.persistence.user;
 
+import de.adesso.budgeteer.core.security.domain.AuthenticationUser;
+import de.adesso.budgeteer.core.security.port.out.GetAuthenticationUserPort;
 import de.adesso.budgeteer.core.user.domain.User;
 import de.adesso.budgeteer.core.user.domain.UserWithEmail;
 import de.adesso.budgeteer.core.user.port.out.*;
@@ -33,7 +35,8 @@ public class UserAdapter implements GetUsersInProjectPort,
         DeleteVerificationTokenByUserIdPort,
         VerificationTokenExistsPort,
         GetVerificationTokenExpirationDatePort,
-        VerifyEmailPort {
+        VerifyEmailPort,
+        GetAuthenticationUserPort {
 
     private final VerificationTokenRepository verificationTokenRepository;
     private final ForgotPasswordTokenRepository forgotPasswordTokenRepository;
@@ -172,5 +175,10 @@ public class UserAdapter implements GetUsersInProjectPort,
     public void verifyEmail(String token) {
         userRepository.verifyEmail(token);
         verificationTokenRepository.deleteByToken(token);
+    }
+
+    @Override
+    public Optional<AuthenticationUser> getAuthenticationUser(String username) {
+        return Optional.ofNullable(userRepository.findByName(username)).map(userMapper::mapToAuthenticationUser);
     }
 }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/user/UserMapper.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/user/UserMapper.java
@@ -1,5 +1,6 @@
 package org.wickedsource.budgeteer.persistence.user;
 
+import de.adesso.budgeteer.core.security.domain.AuthenticationUser;
 import de.adesso.budgeteer.core.user.domain.User;
 import de.adesso.budgeteer.core.user.domain.UserWithEmail;
 import org.springframework.stereotype.Component;
@@ -19,5 +20,9 @@ public class UserMapper {
 
     public List<User> mapToDomain(List<UserEntity> userEntities) {
         return userEntities.stream().map(this::mapToDomain).collect(Collectors.toList());
+    }
+
+    public AuthenticationUser mapToAuthenticationUser(UserEntity userEntity) {
+        return new AuthenticationUser(userEntity.getId(), userEntity.getName(), userEntity.getPassword());
     }
 }


### PR DESCRIPTION
We previously forgot to implement GetAuthenticationUserPort. This caused
the application to no longer start. To help prevent such errors in the
future, a simple test to load the application context was added.