### PR TITLE
security: Provide setup for expression based method security

### DIFF
--- a/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/security/authorization/methodsecurity/BudgeteerMethodSecurityExpressionHandler.java
+++ b/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/security/authorization/methodsecurity/BudgeteerMethodSecurityExpressionHandler.java
@@ -1,0 +1,20 @@
+package de.adesso.budgeteer.rest.security.authorization.methodsecurity;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.security.access.expression.DenyAllPermissionEvaluator;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations;
+import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
+import org.springframework.security.core.Authentication;
+
+public class BudgeteerMethodSecurityExpressionHandler extends DefaultMethodSecurityExpressionHandler {
+
+    @Override
+    protected MethodSecurityExpressionOperations createSecurityExpressionRoot(Authentication authentication, MethodInvocation invocation) {
+        var root = new BudgeteerMethodSecurityExpressionRoot(authentication);
+        root.setPermissionEvaluator(new DenyAllPermissionEvaluator());
+        root.setTrustResolver(new AuthenticationTrustResolverImpl());
+        return root;
+    }
+
+}

--- a/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/security/authorization/methodsecurity/BudgeteerMethodSecurityExpressionRoot.java
+++ b/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/security/authorization/methodsecurity/BudgeteerMethodSecurityExpressionRoot.java
@@ -1,0 +1,41 @@
+package de.adesso.budgeteer.rest.security.authorization.methodsecurity;
+
+import org.springframework.security.access.expression.SecurityExpressionRoot;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations;
+import org.springframework.security.core.Authentication;
+
+public class BudgeteerMethodSecurityExpressionRoot extends SecurityExpressionRoot implements MethodSecurityExpressionOperations {
+
+    private Object filterObject;
+
+    private Object returnObject;
+
+    public BudgeteerMethodSecurityExpressionRoot(Authentication authentication) {
+        super(authentication);
+    }
+
+    @Override
+    public Object getFilterObject() {
+        return this.filterObject;
+    }
+
+    @Override
+    public Object getReturnObject() {
+        return this.returnObject;
+    }
+
+    @Override
+    public void setFilterObject(Object obj) {
+        this.filterObject = obj;
+    }
+
+    @Override
+    public void setReturnObject(Object obj) {
+        this.returnObject = obj;
+    }
+
+    @Override
+    public Object getThis() {
+        return this;
+    }
+}

--- a/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/security/authorization/methodsecurity/MethodSecurityConfig.java
+++ b/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/security/authorization/methodsecurity/MethodSecurityConfig.java
@@ -1,0 +1,17 @@
+package de.adesso.budgeteer.rest.security.authorization.methodsecurity;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
+
+@Configuration
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class MethodSecurityConfig extends GlobalMethodSecurityConfiguration {
+
+    @Override
+    protected MethodSecurityExpressionHandler createExpressionHandler() {
+        return new BudgeteerMethodSecurityExpressionHandler();
+    }
+
+}


### PR DESCRIPTION
This allows us to use expression based method security to secure the REST API.
See the [Spring Docs](https://docs.spring.io/spring-security/site/docs/5.0.7.RELEASE/reference/html/el-access.html) for more details on how to use it.