### PR TITLE
json: Add custom serialization/deserialization of Money

### DIFF
--- a/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/json/MoneyJsonDeserializer.java
+++ b/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/json/MoneyJsonDeserializer.java
@@ -1,0 +1,23 @@
+package de.adesso.budgeteer.rest.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.joda.money.CurrencyUnit;
+import org.joda.money.Money;
+import org.springframework.boot.jackson.JsonComponent;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+@JsonComponent
+public class MoneyJsonDeserializer extends JsonDeserializer<Money> {
+    @Override
+    public Money deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        var node = parser.getCodec().readTree(parser);
+        var currencyCode = ((TextNode) node.get("currencyCode")).textValue();
+        var amount = ((TextNode) node.get("amount")).textValue();
+        return Money.of(CurrencyUnit.of(currencyCode), new BigDecimal(amount));
+    }
+}

--- a/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/json/MoneyJsonSerializer.java
+++ b/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/json/MoneyJsonSerializer.java
@@ -1,0 +1,20 @@
+package de.adesso.budgeteer.rest.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.joda.money.Money;
+import org.springframework.boot.jackson.JsonComponent;
+
+import java.io.IOException;
+
+@JsonComponent
+public class MoneyJsonSerializer extends JsonSerializer<Money> {
+    @Override
+    public void serialize(Money value, JsonGenerator generator, SerializerProvider serializers) throws IOException {
+        generator.writeStartObject();
+        generator.writeStringField("currencyCode", value.getCurrencyUnit().getCode());
+        generator.writeStringField("amount", value.getAmount().toPlainString());
+        generator.writeEndObject();
+    }
+}

--- a/budgeteer-rest/src/test/java/de/adesso/budgeteer/rest/json/MoneyJsonTest.java
+++ b/budgeteer-rest/src/test/java/de/adesso/budgeteer/rest/json/MoneyJsonTest.java
@@ -1,0 +1,35 @@
+package de.adesso.budgeteer.rest.json;
+
+import org.joda.money.CurrencyUnit;
+import org.joda.money.Money;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JsonTest
+@ContextConfiguration(classes = {MoneyJsonSerializer.class, MoneyJsonDeserializer.class})
+class MoneyJsonTest {
+
+    @Autowired
+    private JacksonTester<Money> json;
+
+    @Test
+    void testMoneySerialization() throws IOException {
+        var money = Money.of(CurrencyUnit.EUR, new BigDecimal("123.45"));
+        assertThat(json.write(money)).isEqualToJson("{\"currencyCode\":\"EUR\",\"amount\":\"123.45\"}");
+    }
+
+    @Test
+    void testMoneyDeserialization() throws IOException {
+        var content = "{\"currencyCode\":\"EUR\",\"amount\":\"123.45\"}";
+        var expected = Money.of(CurrencyUnit.EUR, new BigDecimal("123.45"));
+        assertThat(json.parse(content).getObject()).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
Jackson doesn't offer proper serialization/deserialization of the joda-money Money type. So we have to do it ourselves.