### PR TITLE
user: Fix RegisterService hashing the already hashed password

### DIFF
--- a/budgeteer-core/src/main/java/de/adesso/budgeteer/core/user/service/RegisterService.java
+++ b/budgeteer-core/src/main/java/de/adesso/budgeteer/core/user/service/RegisterService.java
@@ -2,7 +2,6 @@ package de.adesso.budgeteer.core.user.service;
 
 import de.adesso.budgeteer.core.user.MailAlreadyInUseException;
 import de.adesso.budgeteer.core.user.OnEmailChangedEvent;
-import de.adesso.budgeteer.core.user.PasswordHasher;
 import de.adesso.budgeteer.core.user.UsernameAlreadyInUseException;
 import de.adesso.budgeteer.core.user.port.in.RegisterUseCase;
 import de.adesso.budgeteer.core.user.port.out.CreateUserPort;
@@ -19,7 +18,6 @@ public class RegisterService implements RegisterUseCase {
     private final UserWithNameExistsPort userWithNameExistsPort;
     private final UserWithEmailExistsPort userWithEmailExistsPort;
     private final CreateUserPort createUserPort;
-    private final PasswordHasher passwordHasher;
     private final ApplicationEventPublisher eventPublisher;
 
     @Override
@@ -30,7 +28,7 @@ public class RegisterService implements RegisterUseCase {
         if (!command.getMail().isBlank() && userWithEmailExistsPort.userWithEmailExists(command.getMail())) {
             throw new MailAlreadyInUseException();
         }
-        var userId = createUserPort.createUser(command.getUsername(), command.getMail(), passwordHasher.hash(command.getPassword()));
+        var userId = createUserPort.createUser(command.getUsername(), command.getMail(), command.getPassword());
         eventPublisher.publishEvent(new OnEmailChangedEvent(userId, command.getUsername(), command.getMail()));
     }
 }

--- a/budgeteer-core/src/test/java/de/adesso/budgeteer/core/user/service/RegisterServiceTest.java
+++ b/budgeteer-core/src/test/java/de/adesso/budgeteer/core/user/service/RegisterServiceTest.java
@@ -2,7 +2,6 @@ package de.adesso.budgeteer.core.user.service;
 
 import de.adesso.budgeteer.core.user.MailAlreadyInUseException;
 import de.adesso.budgeteer.core.user.OnEmailChangedEvent;
-import de.adesso.budgeteer.core.user.PasswordHasher;
 import de.adesso.budgeteer.core.user.UsernameAlreadyInUseException;
 import de.adesso.budgeteer.core.user.port.in.RegisterUseCase;
 import de.adesso.budgeteer.core.user.port.out.CreateUserPort;
@@ -25,7 +24,6 @@ class RegisterServiceTest {
     @Mock private UserWithNameExistsPort userWithNameExistsPort;
     @Mock private UserWithEmailExistsPort userWithEmailExistsPort;
     @Mock private CreateUserPort createUserPort;
-    @Mock private PasswordHasher passwordHasher;
     @Mock private ApplicationEventPublisher eventPublisher;
 
     @Test
@@ -49,31 +47,16 @@ class RegisterServiceTest {
     }
 
     @Test
-    void shouldHashPasswordWhenRegisteringUser() throws UsernameAlreadyInUseException, MailAlreadyInUseException {
-        var command = new RegisterUseCase.RegisterCommand("test", "test@mail", "t3st");
-        when(userWithNameExistsPort.userWithNameExists("test")).thenReturn(false);
-        when(userWithEmailExistsPort.userWithEmailExists("test@mail")).thenReturn(false);
-        when(passwordHasher.hash(anyString())).thenReturn("t35t");
-        when(createUserPort.createUser(anyString(), anyString(), anyString())).thenReturn(1L);
-        doNothing().when(eventPublisher).publishEvent(any());
-
-        registerService.register(command);
-
-        verify(passwordHasher).hash("t3st");
-    }
-
-    @Test
     void shouldCallCreateUserWhenUserIsValid() throws UsernameAlreadyInUseException, MailAlreadyInUseException {
         var command = new RegisterUseCase.RegisterCommand("test", "test@mail", "t3st");
         when(userWithNameExistsPort.userWithNameExists("test")).thenReturn(false);
         when(userWithEmailExistsPort.userWithEmailExists("test@mail")).thenReturn(false);
-        when(passwordHasher.hash(anyString())).thenReturn("t35t");
         when(createUserPort.createUser(anyString(), anyString(), anyString())).thenReturn(1L);
         doNothing().when(eventPublisher).publishEvent(any());
 
         registerService.register(command);
 
-        verify(createUserPort).createUser("test", "test@mail", "t35t");
+        verify(createUserPort).createUser(command.getUsername(), command.getMail(), command.getPassword());
     }
 
     @Test
@@ -81,7 +64,6 @@ class RegisterServiceTest {
         var command = new RegisterUseCase.RegisterCommand("test", "test@mail", "t3st");
         when(userWithNameExistsPort.userWithNameExists("test")).thenReturn(false);
         when(userWithEmailExistsPort.userWithEmailExists("test@mail")).thenReturn(false);
-        when(passwordHasher.hash(anyString())).thenReturn("t35t");
         when(createUserPort.createUser(anyString(), anyString(), anyString())).thenReturn(1L);
         doNothing().when(eventPublisher).publishEvent(any());
 


### PR DESCRIPTION
In the past we used SHA512 to hash password. Since then we switched to BCrypt, but didn't remove the hashing from the RegisterService.
This caused accounts to be unable to log in, since the password was now unusable.