### PR TITLE
Project authorization via method security expression

### DIFF
--- a/budgeteer-core/src/main/java/de/adesso/budgeteer/core/project/port/in/UserHasAccessToProjectUseCase.java
+++ b/budgeteer-core/src/main/java/de/adesso/budgeteer/core/project/port/in/UserHasAccessToProjectUseCase.java
@@ -1,0 +1,5 @@
+package de.adesso.budgeteer.core.project.port.in;
+
+public interface UserHasAccessToProjectUseCase {
+    boolean userHasAccessToProject(String username, long projectId);
+}

--- a/budgeteer-core/src/main/java/de/adesso/budgeteer/core/project/port/out/UserHasAccessToProjectPort.java
+++ b/budgeteer-core/src/main/java/de/adesso/budgeteer/core/project/port/out/UserHasAccessToProjectPort.java
@@ -1,0 +1,5 @@
+package de.adesso.budgeteer.core.project.port.out;
+
+public interface UserHasAccessToProjectPort {
+    boolean userHasAccessToProject(String username, long projectId);
+}

--- a/budgeteer-core/src/main/java/de/adesso/budgeteer/core/project/service/UserHasAccessToProjectService.java
+++ b/budgeteer-core/src/main/java/de/adesso/budgeteer/core/project/service/UserHasAccessToProjectService.java
@@ -1,0 +1,18 @@
+package de.adesso.budgeteer.core.project.service;
+
+import de.adesso.budgeteer.core.project.port.in.UserHasAccessToProjectUseCase;
+import de.adesso.budgeteer.core.project.port.out.UserHasAccessToProjectPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserHasAccessToProjectService implements UserHasAccessToProjectUseCase {
+
+    private final UserHasAccessToProjectPort userHasAccessToProjectPort;
+
+    @Override
+    public boolean userHasAccessToProject(String username, long projectId) {
+        return userHasAccessToProjectPort.userHasAccessToProject(username, projectId);
+    }
+}

--- a/budgeteer-core/src/test/java/de/adesso/budgeteer/core/project/service/UserHasAccessToProjectServiceTest.java
+++ b/budgeteer-core/src/test/java/de/adesso/budgeteer/core/project/service/UserHasAccessToProjectServiceTest.java
@@ -1,0 +1,39 @@
+package de.adesso.budgeteer.core.project.service;
+
+import de.adesso.budgeteer.core.project.port.out.UserHasAccessToProjectPort;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserHasAccessToProjectServiceTest {
+    @Mock private UserHasAccessToProjectPort userHasAccessToProjectPort;
+    @InjectMocks private UserHasAccessToProjectService userHasAccessToProjectService;
+
+    @Test
+    void shouldReturnTrueIfUserHasAccessToProject() {
+        var username = "name";
+        var projectId = 2L;
+        when(userHasAccessToProjectPort.userHasAccessToProject(username, projectId)).thenReturn(true);
+
+        var returned = userHasAccessToProjectService.userHasAccessToProject(username, projectId);
+
+        assertThat(returned).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseIfUserDoesNotHaveAccessToProject() {
+        var username = "unauthorized-name";
+        var projectId = 2L;
+        when(userHasAccessToProjectPort.userHasAccessToProject(username, projectId)).thenReturn(false);
+
+        var returned = userHasAccessToProjectService.userHasAccessToProject(username, projectId);
+
+        assertThat(returned).isFalse();
+    }
+}

--- a/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/project/ProjectController.java
+++ b/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/project/ProjectController.java
@@ -7,6 +7,7 @@ import de.adesso.budgeteer.rest.project.model.ProjectModel;
 import de.adesso.budgeteer.rest.project.model.UpdateDefaultProjectModel;
 import de.adesso.budgeteer.rest.security.userdetails.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,6 +35,7 @@ public class ProjectController {
     }
 
     @GetMapping("/{projectId}")
+    @PreAuthorize("userHasAccessToProject(principal.username, #projectId)")
     public Optional<ProjectModel> getProject(@PathVariable("projectId") long projectId) {
         return Optional.ofNullable(getProjectUseCase.getProject(projectId)).map(projectModelMapper::toModel);
     }

--- a/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/security/authorization/methodsecurity/BudgeteerMethodSecurityExpressionHandler.java
+++ b/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/security/authorization/methodsecurity/BudgeteerMethodSecurityExpressionHandler.java
@@ -1,5 +1,7 @@
 package de.adesso.budgeteer.rest.security.authorization.methodsecurity;
 
+import de.adesso.budgeteer.core.project.port.in.UserHasAccessToProjectUseCase;
+import lombok.RequiredArgsConstructor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.security.access.expression.DenyAllPermissionEvaluator;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
@@ -7,11 +9,14 @@ import org.springframework.security.access.expression.method.MethodSecurityExpre
 import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
 import org.springframework.security.core.Authentication;
 
+@RequiredArgsConstructor
 public class BudgeteerMethodSecurityExpressionHandler extends DefaultMethodSecurityExpressionHandler {
+
+    private final UserHasAccessToProjectUseCase userHasAccessToProjectUseCase;
 
     @Override
     protected MethodSecurityExpressionOperations createSecurityExpressionRoot(Authentication authentication, MethodInvocation invocation) {
-        var root = new BudgeteerMethodSecurityExpressionRoot(authentication);
+        var root = new BudgeteerMethodSecurityExpressionRoot(authentication, userHasAccessToProjectUseCase);
         root.setPermissionEvaluator(new DenyAllPermissionEvaluator());
         root.setTrustResolver(new AuthenticationTrustResolverImpl());
         return root;

--- a/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/security/authorization/methodsecurity/BudgeteerMethodSecurityExpressionRoot.java
+++ b/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/security/authorization/methodsecurity/BudgeteerMethodSecurityExpressionRoot.java
@@ -1,5 +1,7 @@
 package de.adesso.budgeteer.rest.security.authorization.methodsecurity;
 
+import de.adesso.budgeteer.core.project.port.in.GetProjectUseCase;
+import de.adesso.budgeteer.core.project.port.in.UserHasAccessToProjectUseCase;
 import org.springframework.security.access.expression.SecurityExpressionRoot;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations;
 import org.springframework.security.core.Authentication;
@@ -7,11 +9,16 @@ import org.springframework.security.core.Authentication;
 public class BudgeteerMethodSecurityExpressionRoot extends SecurityExpressionRoot implements MethodSecurityExpressionOperations {
 
     private Object filterObject;
-
     private Object returnObject;
+    private final UserHasAccessToProjectUseCase userHasAccessToProjectUseCase;
 
-    public BudgeteerMethodSecurityExpressionRoot(Authentication authentication) {
+    public BudgeteerMethodSecurityExpressionRoot(Authentication authentication, UserHasAccessToProjectUseCase userHasAccessToProjectUseCase) {
         super(authentication);
+        this.userHasAccessToProjectUseCase = userHasAccessToProjectUseCase;
+    }
+
+    public boolean userHasAccessToProject(String username, long projectId) {
+        return userHasAccessToProjectUseCase.userHasAccessToProject(username, projectId);
     }
 
     @Override

--- a/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/security/authorization/methodsecurity/MethodSecurityConfig.java
+++ b/budgeteer-rest/src/main/java/de/adesso/budgeteer/rest/security/authorization/methodsecurity/MethodSecurityConfig.java
@@ -1,17 +1,22 @@
 package de.adesso.budgeteer.rest.security.authorization.methodsecurity;
 
+import de.adesso.budgeteer.core.project.port.in.UserHasAccessToProjectUseCase;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 public class MethodSecurityConfig extends GlobalMethodSecurityConfiguration {
 
+    private final UserHasAccessToProjectUseCase userHasAccessToProjectUseCase;
+
     @Override
     protected MethodSecurityExpressionHandler createExpressionHandler() {
-        return new BudgeteerMethodSecurityExpressionHandler();
+        return new BudgeteerMethodSecurityExpressionHandler(userHasAccessToProjectUseCase);
     }
 
 }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/project/ProjectAdapter.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/project/ProjectAdapter.java
@@ -40,7 +40,8 @@ public class ProjectAdapter implements GetProjectPort,
         RemoveUserFromProjectPort,
         ProjectExistsWithIdPort,
         GetProjectAttributesPort,
-        ProjectHasContractsPort {
+        ProjectHasContractsPort,
+        UserHasAccessToProjectPort {
 
     private final ProjectMapper projectMapper;
     private final ProjectRepository projectRepository;
@@ -172,5 +173,10 @@ public class ProjectAdapter implements GetProjectPort,
     @Override
     public boolean projectHasContracts(long projectId) {
         return projectRepository.hasContracts(projectId);
+    }
+
+    @Override
+    public boolean userHasAccessToProject(String username, long projectId) {
+        return projectRepository.userInAuthorizedUsers(username, projectId);
     }
 }

--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/project/ProjectRepository.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/persistence/project/ProjectRepository.java
@@ -12,6 +12,9 @@ import java.util.Optional;
 @Repository
 public interface ProjectRepository extends CrudRepository<ProjectEntity, Long> {
 
+    @Query("SELECT (count(project) > 0) FROM ProjectEntity project WHERE project.id = :projectId AND :username IN (SELECT user.name FROM project.authorizedUsers user)")
+    boolean userInAuthorizedUsers(@Param("username") String username, @Param("projectId") long projectId);
+
     @Query("select pcf from ProjectContractField pcf where pcf.project.id = :projectId AND pcf.fieldName = :fieldName")
     ProjectContractField findContractFieldByName(@Param("projectId") long projectId, @Param("fieldName") String fieldName);
 


### PR DESCRIPTION
This adds the `userHasAccessToProject(String username, long projectId)` method to the security expression root, and uses it to further secure the endpoint `/projects/{projectId}`.
When a user doesn't have access to the project the user will receive a `403 Forbidden` status code. Otherwise they will get the requested project.
I used the username, instead of the id like usual, since using the username is easier as you can directly pass it to the expression.