### PR TITLE
Fix main branch not building due to spotless

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,4 +48,4 @@ jobs:
         run: ./gradlew spotlessCheck -DmainBranch=$MAIN_BRANCH
 
     env:
-      MAIN_BRANCH: origin/${{ github.event.pull_request.base.ref }}
+      MAIN_BRANCH: "${{ github.event.pull_request.base.ref && format('{0}/{1}', 'origin', github.event.pull_request.base.ref) || ''}}"


### PR DESCRIPTION
Spotless requires a valid branch name, even if it isn't run. This ensures that the `MAIN_BRANCH` variable is only set when building a pull request. This causes the build script to fall back to `main` which should always be available when building `main`.