### PR TITLE
Generate JaCoCo test reports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ subprojects {
     }
 
     test {
+        finalizedBy jacocoTestReport
         useJUnitPlatform()
     }
 


### PR DESCRIPTION
When adding JaCoCo we forgot to enable the generation of reports after tests.
Enabling them allows SonarQube to show proper coverage information.