### PR TITLE
ci: Fix a typo in the output of the check-commit-dates job

### DIFF
--- a/.github/workflows/docker-nightly.yaml
+++ b/.github/workflows/docker-nightly.yaml
@@ -20,7 +20,7 @@ jobs:
           echo ::set-output name=should-run::${SHOULD_RUN}
 
     outputs:
-      should-run: ${{ steps.should_run.outputs.should_run }}
+      should-run: ${{ steps.check-commit-dates.outputs.should-run }}
 
   nightly-prepare-version-info:
     needs: check-commit-dates


### PR DESCRIPTION
The `outputs` of the `check-commit-dates` job read the output of `steps.should_run.outputs.should_run`, which doesn't exist, instead of `steps.check-commit-dates.outputs.should-run`. 
This caused nightly builds not to run, since `needs.check-commit-dates.outputs.should-run` was always false.